### PR TITLE
Fix code list links in DataFrameworks, InformationEntityXMLBindings and RESTWebServiceSpecification

### DIFF
--- a/docs/LCF-DataFrameworks.md
+++ b/docs/LCF-DataFrameworks.md
@@ -167,24 +167,24 @@ An identified manifestation of an abstract work, e.g. a book, magazine, newspape
 |------------|----------------------------|-----------|----------|------------|--------------------------------|
 | **E01D01** | **Identifier**             |           | **1**[4](#Notes)                                                    | **String** | **The LCF identifier used when referring to this manifestation entity.**                                                          |
 | *E01C02*   | *Additional identifier*    |           | 1-n      |            | Composite element containing details of an additional identifier for the manifestation.                                                             |
-| E01D02.1   | Identifier type            |           | 1        | Code       | LCF code list **[MNI](LCF-CodeLists#MNI)**          |
+| E01D02.1   | Identifier type            |           | 1        | Code       | LCF code list **[MNI](LCF-CodeLists.md#MNI)**          |
 | E01D02.2   | Identifier type name       |           | 0-1      | String     | If the identification scheme is proprietary, the name of the scheme.                                                                           |
 | E01D02.3   | Identifier value           |           | 1        | String     | The identifier string.         |
 | *E01C03*   | *Media type / format*      | CK        | 0-n      |            |                                |
-| E01D03.1   | Media type / format scheme |           | 1        | Code       | LCF code list **[MES](LCF-CodeLists#MES)**<br/>Allowed values to include ONIX code lists 150 and 175, SIP2 media type and proprietary                                 |
+| E01D03.1   | Media type / format scheme |           | 1        | Code       | LCF code list **[MES](LCF-CodeLists.md#MES)**<br/>Allowed values to include ONIX code lists 150 and 175, SIP2 media type and proprietary                                 |
 | E01D03.2   | Scheme name                |           | 0-1      | String     | Name or description of proprietary scheme                                                                                                         |
 | E01D03.3   | Scheme code                |           | 1        | String     | Code from the specified scheme |
 | *E01C04*   | *Title*                    | AJ        | 0-n      |            | Composite element containing a title of the manifestation. Repeatable for multiple types of title (e.g. full title, abbreviated title)              |
-| E01D04.1   | Title type                 |           | 1        | Code       | LCF code list **[TTL](LCF-CodeLists#TTL)**          |
+| E01D04.1   | Title type                 |           | 1        | Code       | LCF code list **[TTL](LCF-CodeLists.md#TTL)**          |
 | E01D04.2   | Title text                 |           | 1        | String     |                                |
 | E01D04.3   | Subtitle                   |           | 0-1      | String     |                                |
 | *E01C05*   | *Contributor*              |           | 0-n      |            | Composite element containing author or other contributor. Repeatable for multiple contributors.                                                    |
 | E01D05.1   | Contributor role           |           | 1        | Code       | Contributor role code from ONIX Code List 17[5](#Notes).                                                                        |
 | E01D05.2   | Contributor name           |           | 0-1      | String     | Either a contributor name or an unnamed contributor code must be included in each item contributor composite.                                  |
-| E01D05.3   | Unnamed contributor        |           | 0-1      | Code       | LCF code list **[UNC](LCF-CodeLists#UNC)**          |
+| E01D05.3   | Unnamed contributor        |           | 0-1      | Code       | LCF code list **[UNC](LCF-CodeLists.md#UNC)**          |
 | *E01C06*   | *Series*                   |           | 0-1      |            | Composite element containing information about a series of which this manifestation is a member.                                            |
 | *E01C06.1* | *Series title*             |           | 0-n      |            | Composite element containing the title of the series. Repeatable for multiple types of title.                                                   |
-| E01D06.1.1 | Title type                 |           | 1        | Code       | LCF code list **[TTL](LCF-CodeLists#TTL)**          |
+| E01D06.1.1 | Title type                 |           | 1        | Code       | LCF code list **[TTL](LCF-CodeLists.md#TTL)**          |
 | E01D06.1.2 | Title text                 |           | 1        | String     |                                |
 | E01D06.1.3 | Subtitle                   |           | 0-1      | String     |                                |
 | E01D06.2   | Volume or part             |           | 0-1      | String     | Volume or part number within series                                                                                                         |
@@ -193,27 +193,27 @@ An identified manifestation of an abstract work, e.g. a book, magazine, newspape
 | E01D08     | Publisher name             |           | 0-1      | String     | Name of the publisher of the manifestation                                                                                                  |
 | E01D09     | Year of publication        |           | 0-1      | YYYY       | Year of publication of the manifestation                                                                                                  |
 | *E01C10*   | *Classification*           |           | 0-n      |            |                                |
-| E01D10.1   | Classification scheme      |           | 1        | Code       | LCF code list **[LCS](LCF-CodeLists#LCS)**          |
+| E01D10.1   | Classification scheme      |           | 1        | Code       | LCF code list **[LCS](LCF-CodeLists.md#LCS)**          |
 | E01D10.2   | Scheme name                |           | 0-1      | String     | Name or description of proprietary scheme                                                                                                         |
 | E01D10.3   | Scheme code                |           | 1        | String     |                                |
 | E01D11     | Item cover art             |           | 0-n      | URI        | URI reference to cover art resource                                                                                                       |
 | E01D12     | Other description          |           | 0-1      | String     | Other descriptive information about the manifestation.                                                                                             |
 | *E01C13*   | *Check-out restriction*    |           | 0-n      |            | Composite element containing details of a restriction on check-out of this manifestation. Repeatable for multiple restriction types.                |
-| E01D13.1   | Restriction type           |           | 1        | Code       | LCF code list **[CRT](LCF-CodeLists#CRT)**<br/>The type of restriction imposed.                                                                                        |
+| E01D13.1   | Restriction type           |           | 1        | Code       | LCF code list **[CRT](LCF-CodeLists.md#CRT)**<br/>The type of restriction imposed.                                                                                        |
 | E01D13.2   | Restriction code / value   |           | 1        | String     | Restriction value of the specified type.                                                                                                          |
 | E01D13.3   | Restriction note           |           | 0-1      | String     | Free-text note or description of the restriction.                                                                                                   |
 | *E01C14*   | *Check-out fee*            | BO        | 0-n      |            | Composite element containing details of any fee required to check out this manifestation. Repeatable if there are fees of different types. NOTE – Infrequently used, as fees are rarely fixed for an individual manifestation and must be calculated at check-out time, based upon a variety of factors.                                                                         |
-| E01D14.1   | Fee type                   | BT        | 1        | Code       | LCF code list **[CHT](LCF-CodeLists#CHT)**          |
+| E01D14.1   | Fee type                   | BT        | 1        | Code       | LCF code list **[CHT](LCF-CodeLists.md#CHT)**          |
 | E01D14.2   | Fee amount                 | BV        | 1        | Value      | Currency value                 |
 | E01D14.3   | Fee currency               | BH        | 0-1      | Code       | ISO three-letter currency code, e.g. ‘GBP’                                                                                                          |
 | E01D15     | Number of patrons in hold queue | CF   | 0-1R[6](#Notes)                                                    | Integer    |                                |
 | E01D16     | Manifestation record reference  |      | 0-1      | String     | A reference (e.g. URI or query string) for retrieving a catalogue record for this manifestation from the LMS or online catalogue.             |
-| **E01D17** | **Manifestation status**   |           | **1**    | **Code**   | LCF code list **[MNS](LCF-CodeLists#MNS)**          |
+| **E01D17** | **Manifestation status**   |           | **1**    | **Code**   | LCF code list **[MNS](LCF-CodeLists.md#MNS)**          |
 | E01D18     | Number of copies in stock / holding |  | 0-1R     | Integer    |                                |
 | E01D19     | Item reference             |           | 0-nR     | String     | Reference to an item that is a copy of this manifestation                                                                                          |
 | E01D20     | Reservation reference      |           | 0-nR     | String     | If this manifestation has been reserved, a reference to the reservation record in the hold queue. Repeatable if there are multiple reservations in the “hold queue”.                                                                                              |
 | *E01C21*   | *Manifestation note*       |           | 0-n      |            | A note attached to the LMS record for this title.                                                                                                |
-| E01D21.1   | Note type                  |           | 0-1      | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| E01D21.1   | Note type                  |           | 0-1      | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E01D21.2   | Note date-time             |           | 0-1      | DateTime   |                                |
 | E01D21.3   | Note text                  |           | 1        | String     |                                |
 
@@ -232,33 +232,33 @@ An identified copy of a manifestation that is in a library's stock / holding.
 |------------|----------------------------|-----------|----------|------------|--------------------------------|
 | **E02D01** | **Identifier**             | **AB**    | **1**[4](#Notes)                                                   | **String** | **The LCF identifier normally used when referring to this item entity.**                                                                          |
 | *E02C02*   | *Additional identifier*    |           | 0-n      |            | Composite element containing details of an additional identifier for this item.                                                                     |
-| E02D02.1   | Identifier type            |           | 1        | Code       | LCF code list **[IMI](LCF-CodeLists#IMI)**<br/>The identification scheme.                                                                                         |
+| E02D02.1   | Identifier type            |           | 1        | Code       | LCF code list **[IMI](LCF-CodeLists.md#IMI)**<br/>The identification scheme.                                                                                         |
 | E02D02.2   | Identifier type name       |           | 0-1      | String     | If the identification scheme is proprietary, the name of the scheme.                                                                           |
 | E02D02.3   | Identifier value           |           | 1        | String     | The identifier string.         |
 | **E02D03** |**Manifestation reference** |           | **1**    | **String** | **Reference to the manifestation of which this item is an instance.**                                                                              |
 | E02D04     | Item properties            | CH        | 0-1      | String     | Descriptive information about this item.                                                                                                          |
 | E02D05     | Item owner                 | BG        | 0-1      | String     | A reference to an Institution entity (see E14) representing the owner of this item *(Modified description in v1.0.1)*                               |
 | *E02C06*   | *Associated location*      |           | 0-n      |            | A location associated with this item.|
-| E02D06.1   | Location association type  |           | 1        | Code       | LCF code list **[LAT](LCF-CodeLists#LAT)**                                                                                                  |
+| E02D06.1   | Location association type  |           | 1        | Code       | LCF code list **[LAT](LCF-CodeLists.md#LAT)**                                                                                                  |
 | E02D06.2   | Location reference         |           | 1        | String     | *Cardinality corrected in v1.0.1* |
 | E02D07     | Item sensitive media warning |         | 1        | Code       | LCF code list **[MEW](LCF-CodeLists#MEW)**<br/>Flag indicating that the item contains a media component that is sensitive to some security setting devices.                                                                                                       |
 | E02D08     | Desensitize item security  |           | 0-1      | Code       | LCF code list **[SCD](LCF-CodeLists#SCD)**<br/>Flag indicating that the security should or should not be desensitized / removed on check-out. |
 | *E02C09*   | *Check-out restriction*    |           | 0-n      |            | Composite element containing details of a restriction on check-out of this item. Repeatable for multiple restriction types. Overrides the same check-out restrictions specified for the title.                                                                          |
-| E02D09.1   | Restriction type           |           | 1        | Code       | LCF code list **[CRT](LCF-CodeLists#CRT)**                                                                                                  |
+| E02D09.1   | Restriction type           |           | 1        | Code       | LCF code list **[CRT](LCF-CodeLists.md#CRT)**                                                                                                  |
 | E02D09.2   | Restriction code / value   |           | 1        | String     | Restriction value of the specified type.                                                                                                          |
 | E02D09.3   | Restriction note           |           | 0-1      | String     | Free-text note or description of the restriction.                                                                                                   |
 | *E02C10*   | *Check-out fee*            | BO        | 0-n      |            | Composite element containing details of any fee required to check out this item. Repeatable if there are fees of different types. NOTE – Rarely used, as fees are rarely fixed for an item and must be calculated at check-out time, based upon a variety of factors. If included, Overrides the same check-out fees specified for the title.                                           |
-| E02D10.1   | Fee type                   | BT        | 1        | Code       | LCF code list **[CHT](LCF-CodeLists#CHT)**          |
+| E02D10.1   | Fee type                   | BT        | 1        | Code       | LCF code list **[CHT](LCF-CodeLists.md#CHT)**          |
 | E02D10.2   | Fee amount                 | BV        | 1        | Value      | Currency value                 |
 | E02D10.3   | Fee currency               | BH        | 0-1      | Code       | ISO three-letter currency code, e.g. ‘GBP’                                                                                                          |
-| **E02D11** | **Circulation status**     |           | **1**    | **Code**   | **LCF code list [CIS](LCF-CodeLists#CIS)**          |
+| **E02D11** | **Circulation status**     |           | **1**    | **Code**   | **LCF code list [CIS](LCF-CodeLists.md#CIS)**          |
 | E02D12     | Reservation reference      |           | 0-nR     | String     | If this item has been reserved, a reference to the reservation record in the hold queue. Repeatable if there are multiple reservations in the “hold queue”.                                                                                                        |
 | E02D13     | Number of patrons in hold queue | CF   | 0-1R     | Integer    | Included only if this specific item is specified in the hold queue.                                                                                |
 | E02D14     | Loan reference             |           | 0-1R     | String     | If this item is on loan, a reference to the active loan record is mandatory.                                                                        |
 | E02D15     | Condition code / value     |           | 0-n      | Code       | A proprietary (i.e. LMS-specific) code value indicating the condition of the item.                                                               |
 | E02D16     | Condition description      |           | 0-1      | String     | A textual description of the condition of the item.                                                                                         |
 | *E02C17*   | *Item note*                |           | 0-n      |            | A note attached to the LMS record for this item.                                                                                                 |
-| E02D17.1   | Note type                  |           | 0-1      | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| E02D17.1   | Note type                  |           | 0-1      | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E02D17.2   | Note date-time             |           | 0-1      | DateTime   |                                |
 | E02D17.3   | Note text                  |           | 1        | String     |                                |
 
@@ -281,27 +281,27 @@ NOTE – Contact information is held in separate contact records for security an
 | **E03D01** | **Identifier**             | **AA**    | **1**[4](#Notes)                                                    | **String** | **The LCF entity identifier normally used when referring to this patron.**                                                                          |
 | E03D26     | Barcode identifier         |           | 0-1      | String     | The identifier on the patron's library card. Mandatory unless the LCF entity identifier is the same identifier.<br/>*Added v1.0.1*            |
 | *E03C27*   | *Additional identifier*    |           | 0-n      |            | Composite element containing details of an additional identifier for this patron.<br/>*Added v1.0.1*                                                |
-| E03D27.1   | Identifier type            |           | 1        | Code       | LCF code list **[PNI](LCF-CodeLists#PNI)**<br/>The identification scheme.                                                                                         |
+| E03D27.1   | Identifier type            |           | 1        | Code       | LCF code list **[PNI](LCF-CodeLists.md#PNI)**<br/>The identification scheme.                                                                                         |
 | E02D27.2   | Identifier type name       |           | 0-1      | String     | If the identification scheme is proprietary, the name of the scheme.                                                                           |
 | E02D27.3   | Identifier value           |           | 1        | String     | The identifier string.         |
 | **E03D22** | **Name**                   | **AE**    | **1**    | **String** | **Name of primary contact for this patron.**<br/>*Added v1.0.1*                                                                                   |
 | E03D02     | Contact reference          |           | 0-n      | String     | Contact details for this patron<br/>*Repeatable v1.0.1*                                                                                 |
 | E03D23     | Language                   |           | 0-1      | Code       | Language for communication with primary contact<br/>ISO three-letter language code, e.g. ‘eng’<br/>*Added v1.0.1*                              |
 | *E03C03*   | *Associated location*      |           | 0-n      |            | A location associated with this patron.                                                                                                        |
-| E03D03.1   | Location association type  |           | 1        | Code       | LCF code list **[LAT](LCF-CodeLists#LAT)**          |
+| E03D03.1   | Location association type  |           | 1        | Code       | LCF code list **[LAT](LCF-CodeLists.md#LAT)**          |
 | E03D03.2   | Location reference         |           | 1        | String     | *Cardinality corrected in v1.0.1* |
 | E03D34     | Patron's home institution  |           | 0-1      | String     | Patron's home library/institution as represented by an Authority / Institution entity (E14)<br/>*(Added v1.0.1)*                                    |
-| E03D04     | Patron status              |           | 0-nR     | Code       | LCF code list **[PNS](LCF-CodeLists#PNS)**              |
+| E03D04     | Patron status              |           | 0-nR     | Code       | LCF code list **[PNS](LCF-CodeLists.md#PNS)**              |
 | **<strike>E03D04.1</strike>** | **<strike>Condition</strike>** |            | **<strike>1-n</strike>** | **<strike>Code</strike>** |                                                                   *Removed v1.0.1* |
 | *E03C24*   | *Library card status information* |    | 0-1R     |            | Status information on the patron's library card.<br/>*Added v1.0.1*                                                                               |
-| E03D24.1   | Library card status        |           | 1R       | Code       | LCF code list **[PCS](LCF-CodeLists#PCS)**<br/>*ID changed from E03C05 in v1.0.1*                                                           |
+| E03D24.1   | Library card status        |           | 1R       | Code       | LCF code list **[PCS](LCF-CodeLists.md#PCS)**<br/>*ID changed from E03C05 in v1.0.1*                                                           |
 | E03D24.2   | Blocked card message       | AL        | 0-1R     | String     |*ID changed from E03D06 in v1.0.1* |
 | E03D28     | Patron category            |           | 0-1      | String     | Library-specific code<br/>*Added v1.0.1*                                                                                                        |
 | E03D29     | Patron tag                 |           | 0-n      | String     | Library-specific tag<br/>*Added v1.0.1*                                                                                                        |
 | E03D32     | Patron authorisation code/reference |  | 0-n      | String     | An authorisation code assigned to this patron - See [E13](#e13).<br/>*Added v1.0.1*                                                                   |
 | E03D30     | Patron expiration date     |           | 0-1      | Date       | Date upon which this Patron account expired or is due to expire<br/>*Added v1.0.1*                                                                 |
 | *E03C33*   | *Associated patron group*  |           | 0-n    |            | A group of patrons with which this patron is associated either as a leader or a member.<br/>*Added v1.0.1*                                        |
-| E03D33.1   | Patron group association type |        | 1        | Code       | LCF code list **[PGP](LCF-CodeLists#PGP)**                                                                                                  |
+| E03D33.1   | Patron group association type |        | 1        | Code       | LCF code list **[PGP](LCF-CodeLists.md#PGP)**                                                                                                  |
 | E03D33.5   | Patron group type          |           | 0-1      | String     | A code assigned by the LMS, indicating the type of group, e.g. 'family', 'school'                                                                     |
 | E03D33.2   | Patron group identifier    |           | 0-1      | String     | A unique identifier of the group |
 | E03D33.3   | Lead patron reference      |           | 0-n      | String     | A leader of the group. A leader is a Patron entitled to perform actions on behalf of any member of the group.                                       |
@@ -320,7 +320,7 @@ NOTE – Contact information is held in separate contact records for security an
 | E03D18     | Hold items limit           | BZ        | 0-1      | Integer    |                                |
 | E03D19     | Charge reference           |           | 0-nR     | String     | A charge associated with this patron. It is recommended that a patron record should include references to all unpaid charges.                        |
 | *E03C20*   | *Charge limit*             | CC        | 0-n      |            | Composite element. The limit on charges (fees or fines) that this patron is allowed to owe. Repeatable if separate limits are specified for charges of different types.                                                                                               |
-| E03D20.1   | Charge type                | BT        | 0-1      | Code       | LCF code list **[CHT](LCF-CodeLists#CHT)**<br/>May only be omitted if there is only one occurrence of the charge limit composite, in which case the amount is the limit on the aggregate of charges of all types.                                                  |
+| E03D20.1   | Charge type                | BT        | 0-1      | Code       | LCF code list **[CHT](LCF-CodeLists.md#CHT)**<br/>May only be omitted if there is only one occurrence of the charge limit composite, in which case the amount is the limit on the aggregate of charges of all types.                                                  |
 | E03D20.2   | Charge amount              | BV        | 1        | Value      | Currency value                 |
 | E03D20.3   | Charge currency            | BH        | 0-1      | Code       | ISO three-letter currency code, e.g. ‘GBP’                                                                                                          |
 | *E03C31*   | *Deposit balance*          |           | 0-1      |            | Balance of funds deposited, if the Patron maintains a balance available for settling future charges or fines<br/>*Added v1.0.1*                          |
@@ -328,9 +328,9 @@ NOTE – Contact information is held in separate contact records for security an
 | E03D31.2   | Deposit currency           |           | 0-1      | Code       | ISO three-letter currency code, e.g. ‘GBP’                                                                                                          |
 | E03C34     | Associated message/alert   |           | 0-n      |            | A message/alert for display<br/>*Added v1.0.1*                                                                                                        |
 | E03D34.1   | Message reference          |           | 1        | String     |                                |
-| E03D34.2   | Message delivery status    |           | 0-1      | Code       | LCF code list **[MAD](LCF-CodeLists#MAD)**<br/>                                                                                             |
+| E03D34.2   | Message delivery status    |           | 0-1      | Code       | LCF code list **[MAD](LCF-CodeLists.md#MAD)**<br/>                                                                                             |
 | *E03C21*   | *Patron note*              |           | 0-n      |            | A note attached to the LMS record for this patron.                                                                                                        |
-| E03D21.1   | Note type                  |           | 0-1      | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| E03D21.1   | Note type                  |           | 0-1      | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E03D21.2   | Note date-time             |           | 0-1      | DateTime   |                                |
 | E03D21.3   | Note text                  |           | 1        | String     |                                |
 | E03D25     | Date of birth              |           | 0-1      | Date       | Date of birth of the primary contact for this patron.<br/>*Added v1.0.1*                                                                            |
@@ -348,18 +348,18 @@ An identified place where an item may be located, either inside or outside a lib
 |------------|----------------------------|-----------|----------|------------|--------------------------------|
 | **E04D01** | **Identifier**             |           | **1**[4](#Notes)                                                    | **String** | **The LCF entity identifier normally used when referring to this location.**                                                                        |
 | *E04C02*   | *Additional identifier*    |           | 0-n      |            | Composite element containing details of an additional identifier for this location.                                                                 |
-| E04D02.1   | Identifier type            |           | 1        | Code       | LCF code list **[LOI](LCF-CodeLists#LOI)**<br/>The identification scheme                                                                                          |
+| E04D02.1   | Identifier type            |           | 1        | Code       | LCF code list **[LOI](LCF-CodeLists.md#LOI)**<br/>The identification scheme                                                                                          |
 | E04D02.2   | Identifier type name       |           | 0-1      | String     | If the identification scheme is proprietary, the name of the scheme.                                                                           |
 | E04D02.3   | Identifier value           |           | 1        | String     | The identifier string.         |
 | E04D03     | Location name              |           | 0-1      | String     |                                |
-| E04D04     | Location type              |           | 0-1      | Code       | LCF code list **[LOT](LCF-CodeLists#LOT)**              |
+| E04D04     | Location type              |           | 0-1      | Code       | LCF code list **[LOT](LCF-CodeLists.md#LOT)**              |
 | E04D05     | Location description       |           | 0-1      | String     |                                |
 | E04D07     | Contact reference          |           | 0-n      | String     | *Added v1.0.1*                 |
 | *E04C08*   | *Associated location*      |           | 0-n      |            | A location associated with this location.<br/>*Added v1.0.1*                                                                                            |
-| E04D08.1   | Location association type  |           | 1        | Code       | LCF code list **[LAT](LCF-CodeLists#LAT)**          |
+| E04D08.1   | Location association type  |           | 1        | Code       | LCF code list **[LAT](LCF-CodeLists.md#LAT)**          |
 | E04D08.2   | Location reference         |           | 1        | String     | *Cardinality corrected in v1.0.1* |
 | *E04C06*   | *Location note*            |           | 0-n      |            | A note attached to the LMS record for this location.                                                                                             |
-| E04D06.1   | Note type                  |           | 0-1      | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| E04D06.1   | Note type                  |           | 0-1      | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E04D06.2   | Note date-time             |           | 0-1      | DateTime   |                                |
 | E04D06.3   | Note text                  |           | 1        | String     |                                |
 
@@ -382,16 +382,16 @@ An identified event in which one or more items have been loaned to a patron.
 | **E05D04** | **Loan start date-time**   |           | **1**    |**DateTime**|                                |
 | E05D05     | Loan end due date-time     |           | 0-1      | DateTime   | Omitted only if the loan is permanent or doesn't have a specific end date-time.                                                                         |
 | E05D06     | Loan end date-time         |           | 0-1      | DateTime   | Actual end date-time. Used when recording past loans.                                                                                                    |
-| **E05D07** | **Loan status**            |           | **1-n**  | **Code**   | **LCF code list [LOS](LCF-CodeLists#LOS)**          |
+| **E05D07** | **Loan status**            |           | **1-n**  | **Code**   | **LCF code list [LOS](LCF-CodeLists.md#LOS)**          |
 | *E05C13*   | Digital item access link   |           | 0-n      |            | A link to access the loaned item, typically only generated when the Loan entity is retrieved<br/>*Added v1.0.1*                                            |
-| E05D13.1   | Link type                  |           | 1        | Code       | LCF code list [LKT](LCF-CodeLists#LKT)<br/> |
+| E05D13.1   | Link type                  |           | 1        | Code       | LCF code list [LKT](LCF-CodeLists.md#LKT)<br/> |
 | E05D13.2   | Link                       |           | 1        | String     |                                |
 | E05D08     | Previous loan reference    |           | 0-1      | String     | Used when loan is a renewal                                                                                                        |
 | E05D09     | Renewal loan reference     |           | 0-1R     | String     | Used when loan is superceded by a renewal loan                                                                                                           |
 | E05D10     | Recall notice date-time    | CJ        | 0-nR     | DateTime   | The date on which a recall notice for the item on loan was issued.                                                                                       |
 | E05D11     | Charge reference           |           | 0-nR     | String     |                                |
 | *E05C12*   | *Loan note*                |           | 0-n      |            | A note attached to the LMS record for this loan.                                                                                                          |
-| E05D12.1   | Note type                  |           | 0-1      | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| E05D12.1   | Note type                  |           | 0-1      | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E05D12.2   | Note date-time             |           | 0-1      | DateTime   |                                |
 | E05D12.3   | Note text                  |           | 1        | String     |                                |
 
@@ -409,7 +409,7 @@ An identified event in which one or more titles have been reserved for a patron.
 | *Id*       | *Element*                   | *SIP2 ID* | *Card.* | *Format*   | *Description*                  |
 |------------|-----------------------------|-----------|---------|------------|--------------------------------|
 | **E06D01** | **Reservation identifier**  |           | **1**[4](#Notes)                                                    | **String** | **The LCF entity identifier used when referring to this reservation.**                                                                          |
-| **E06D02** | **Reservation type**        |           | **1**   | **Code**   | **LCF code list [RVT](LCF-CodeLists#RVT)**          |
+| **E06D02** | **Reservation type**        |           | **1**   | **Code**   | **LCF code list [RVT](LCF-CodeLists.md#RVT)**          |
 | **E06D03** | **Patron reference**        | **AA**    | **1**   | **String** |                                |
 | E06D04     | Manifestation reference     |           | 0-1     | String     | A reservation applies to either a single manifestation or a single item. Each reservation must have one or the other but not both.               |
 | E06D05     | Item reference              |           | 0-1     | String     |                                |
@@ -418,12 +418,12 @@ An identified event in which one or more titles have been reserved for a patron.
 | E06D08     | Pick-up location reference  |           | 0-1     | String     | The LCF entity identifier of the location within the site where the items are to be picked up by the patron. Normally only included if the reservation type is ‘04’, either instead of or additional to E06D07.                                           |
 | E06D09     | Pickup by date-time         | CM        | 0-1     | DateTime   | The date and optionally time by which the reserved item must be collected by the patron.                                                       |
 | E06D10     | End date-time               |           | 0-1     | DateTime   | The date-time when the reservation ended, when the item was checked-out to the patron who had reserved it. Used when recording past reservations. |
-| **E06D11** | **Reservation status**      |           | **1**   | **Code**   | **LCF code list [RVS](LCF-CodeLists#RVS)**          |
+| **E06D11** | **Reservation status**      |           | **1**   | **Code**   | **LCF code list [RVS](LCF-CodeLists.md#RVS)**          |
 | E06D15     | Position in hold queue      |           | 0-1     | Integer    | Position of the reserved item in the hold queue<br/>*Added in v1.0.1*                                                                               |
 | E06D12     | Loan reference              |           | 0-1R    | String     | Only included if maintaining records of reservations that have ended with the item being loaned to the patron.                                      |
 | E06D13     | Charge reference            |           | 0-nR      String     | Reference to a charge incurred by this reservation.                                                                                              |
 | *E06C14*   | *Reservation note*          |           | 0-n     |            | A note attached to this reservation.|
-| E06D14.1   | Note type                   |           | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| E06D14.1   | Note type                   |           | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E06D14.2   | Note date-time              |           | 0-1     | DateTime   |                                |
 | E06D14.3   | Note text                   |           | 1       | String     |                                |
 
@@ -442,8 +442,8 @@ An identified charge made to a patron. May be a fee or a fine.
 |------------|----------------------------|------------|---------|------------|--------------------------------|
 | **E07D01** | **Charge identifier**      | **CG**     | **1**[4](#Notes)                                                    | **String** | **The LCF entity identifier used when referring to this charge.**                                                                               |
 | **E07D02** | **Patron reference**       | **AA**     | **1**   | **String** |                                |
-| **E07D03** | **Charge type**            | **BT**     | **1**   | **Code**   | **LCF code list [CHT](LCF-CodeLists#CHT)<br/>The type or category of charge.**                                                                                          |
-| **E07D04** | **Charge status**          |            | **1**   | **Code**   | **LCF code list [CHS](LCF-CodeLists#CHS)**          |
+| **E07D03** | **Charge type**            | **BT**     | **1**   | **Code**   | **LCF code list [CHT](LCF-CodeLists.md#CHT)<br/>The type or category of charge.**                                                                                          |
+| **E07D04** | **Charge status**          |            | **1**   | **Code**   | **LCF code list [CHS](LCF-CodeLists.md#CHS)**          |
 | E07D05     | Charge description         |            | 0-1     | String     | Free-text description of charge. |
 | E07D06     | item reference             | AB         | 0-1     | String     | An item to which this charge relates. Normally the single most precise reference (e.g. loan) will be sufficient.                            |
 | E07D07     | Manifestation reference    |            | 0-1     | String     | A manifestation to which this charge relates. Normally the single most precise reference (e.g. loan) will be sufficient.                            |
@@ -458,7 +458,7 @@ An identified charge made to a patron. May be a fee or a fine.
 | E07D16     | Payment date-time          |            | 0-1     | DateTime   | The date on which the charge was paid in full. Used when recording past charges.                                                                |
 | E07D17     | Payment reference          |            | 0-n     | String     | Reference to a payment that wholly or partly clears this charge.                                                                                  |
 | *E07C18*   | *Charge note*              |            | 0-n     |            | A note attached to this charge.|
-| E07D18.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| E07D18.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E07D18.2   | Note date-time             |            | 0-1     | DateTime   |                                |
 | E07D18.3   | Note text                  |            | 1       | String     |                                |
 
@@ -477,16 +477,16 @@ An identified payment made by a patron to settle one or more charges.
 |------------|----------------------------|------------|---------|------------|--------------------------------|
 | **E08D01** | **Payment identifier**     | **AA**     | **1**[4](#Notes)                                                    | **String** | **The LCF entity identifier used when referring to this payment.**                                                                              |
 | **E08D02** | **Patron reference**       |            | **1**   | **String** |                                |
-| **E08D03** | **Payment type**           |            | **1**   | **Code**   | **LCF code list [PYT](LCF-CodeLists#PYT)<br/>The type or method of payment.**                                                                                           |
+| **E08D03** | **Payment type**           |            | **1**   | **Code**   | **LCF code list [PYT](LCF-CodeLists.md#PYT)<br/>The type or method of payment.**                                                                                           |
 | E08D04     | Payment description        |            | 0-1     | String     | Further information on type or method of payment.                                                                                             |
 | E08D05     | Charge reference           |            | 0-n     | String     | One or more charges to which this payment relates.<br/>*Non-mandatory in v1.0.1, to allow for payments that don't relate to specific charges, but simply credit an account.*                                                                                            |
 | E08D06     | Payment date-time          |            | 0-1     |            | The date and optionally time at which the payment was made.                                                                                    |
 | **E08D07** | **Payment amount**         | **BV**     | **1**   | **Value**  | **Currency value**             |
 | E08D08     | Payment currency           | BH         | 0-1     | Code       | ISO three-letter currency code, e.g. ‘GBP’                                                                                                          |
-| E08D09     | Payment status             |            | 0-1     | Code       | LCF code list **[PYS](LCF-CodeLists#PYS)**          |
+| E08D09     | Payment status             |            | 0-1     | Code       | LCF code list **[PYS](LCF-CodeLists.md#PYS)**          |
 | E08D10     | Transaction reference      |            | 0-1     | String     |                                |
 | *E08C11*   | *Payment note*             |            | 0-n     | String     |A note attached to this payment.|
-| E08D11.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| E08D11.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E08D11.2   | Note date-time             |            | 0-1     | DateTime   |                                |
 | E08D11.3   | Note text                  |            | 1       | String     |                                |
 
@@ -510,11 +510,11 @@ Contact details for the primary contact person or organization for a patron, loc
 | E09D11     | Authority/Institution reference |       | 0-1     | String     | *Added v1.0.1*                 |
 | <strike>E09D04</strike> | <strike>Address</strike> | <strike>BD</strike> | <strike>0-n</strike> | <strike>String</strike> | <strike>Repeatable if address is divided into multiple lines. Not included if a location entity exists for this address.</strike><br/>                                                 *Removed v1.0.1* |
 | *<strike>E09C05</strike>* | *<strike>Communication details</strike>* |        | <strike>0-n</strike> |      | <strike>Composite element containing a single communication number, address or locator for the patron. Repeatable for different communication types.</strike><br/>                                              *Removed v1.0.1* |
-| **E09D08** | **Communication type**     |            | **1**   | **Code**   | **LCF code list [CMT](LCF-CodeLists#CMT)**<br/>*Added v1.0.1*                                                                                                        |
+| **E09D08** | **Communication type**     |            | **1**   | **Code**   | **LCF code list [CMT](LCF-CodeLists.md#CMT)**<br/>*Added v1.0.1*                                                                                                        |
 | **E09D09** | **Communication locator**  |            | **1-n** | **String** | The number, address or locator<br/>*Added v1.0.1*                                                                                   |
 | **<strike>E09D06</strike>** | **<strike>Language</strike>** |        | **<strike>1</strike>** | **<strike>Code</strike>** | **<strike>Language for communication with contact<br/>ISO three-letter language code, e.g. ‘eng’</strike>**<br/>                                                                    *Removed v1.0.1* |
 | *E09C07*   | *Contact note*             |            | 0-n     |            | A note attached to the LMS record for this contact.                                                                                              |
-| E09D07.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| E09D07.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E09D07.2   | Note date-time             |            | 0-1     | DateTime   |                                |
 | E09D07.3   | Note text                  |            | 1       | String     |                                |
 
@@ -534,7 +534,7 @@ An identified scheme for classification of titles.
 | **E10D01** | **Classification scheme identifier** |  | **1**[4](#Notes)                                                    | **String** | **The LCF entity identifier used when referring to this scheme.**                                                                               |
 | **E10D02** | **Scheme name**            |            | **1**   | **String** | **A name or short description of the scheme**                                                                                                       |
 | *E10C03*   | *Scheme description / note*|            | 0-n     |            | Further, more extensive description of the scheme                                                                                                  |
-| E10D03.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| E10D03.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E10D03.2   | Note date-time             |            | 0-1     | DateTime   |                                |
 | E10D03.3   | Note text                  |            | 1       | String     |                                |
 
@@ -556,7 +556,7 @@ A classification term in an identified scheme for classification of titles.
 | **E11D03** | **Classification scheme reference** |   | **1**   | **String** | **The LCF entity identifier for the classification scheme to which this classification term belongs**                                              |
 | E11D04     | Classification term heading|            | 0-1     | String     | A heading or name for the classification term.                                                                                           |
 | *E11C05*   | *Classification description / note* |   | 0-n     |            |                                |
-| E11D05.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| E11D05.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E11D05.2   | Note date-time             |            | 0-1     | DateTime   |                                |
 | E11D05.3   | Note text                  |            | 1       | String     |                                |
 
@@ -577,11 +577,11 @@ An identified property of an entity that can be used as a selection criterion wh
 |------------|----------------------------|------------|---------|------------|--------------------------------|
 | **E12D01** | **Identifier**             |            | **1**[4](#Notes)                                                    | **String** | **The LCF entity identifier used when referring to this selection criterion.**                                                                  |
 | **E12D02** | **Criterion type name**    |            | **1**   | **String** | **Name of the selection criterion type, to be used in item list requests.**                                                                      |
-| E12D03     | Entity type                |            | 0-n     | Code       | LCF code list **[ENT](LCF-CodeLists#ENT)**<br/>If applicable, the types of entity for which this is a valid selection criterion.                                 |
+| E12D03     | Entity type                |            | 0-n     | Code       | LCF code list **[ENT](LCF-CodeLists.md#ENT)**<br/>If applicable, the types of entity for which this is a valid selection criterion.                                 |
 | E12D04     | Criterion type description |            | 0-1     | String     | A description of the criterion type and the domain and range of its values.                                                                        |
 | E12D05     | Criterion value scheme     |            | 0-1     | String     | Identifier of the scheme from which values of this criterion type are drawn, to be used in item list requests.                                     |
 | *E12C06*   | *Criterion note*           |            | 0-n     |            |                                |
-| E12D06.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| E12D06.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E12D06.2   | Note date-time             |            | 0-1     | DateTime   |                                |
 | E12D06.3   | Note text                  |            | 1       | String     |                                |
 
@@ -601,10 +601,10 @@ A patron authorisation code.
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*   | *Description*                  |
 |------------|----------------------------|------------|---------|------------|--------------------------------|
 | **E13D01** | **Authorisation identifier** |          | **1**[4](#Notes)                                                    | **String** | **The LCF entity identifier used when referring to this authorisation.**                        |
-| E13D02     | Authorisation type         |            | 0-1     | Code       | LCF code list **[AUT](LCF-CodeLists#AUT)**                                                                                                    |
+| E13D02     | Authorisation type         |            | 0-1     | Code       | LCF code list **[AUT](LCF-CodeLists.md#AUT)**                                                                                                    |
 | E13D03     | Authorisation heading      |            | 0-1     | String     | A heading or name for the authorisation. Must be omitted if E13D02 is included.                                                          |
 | *E13C04*   | *Authorisation description / note* |    | 0-n     |            |                                |
-| E13D04.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| E13D04.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E13D04.2   | Note date-time             |            | 0-1     | DateTime   |                                |
 | E13D04.3   | Note text                  |            | 1       | String     |                                |
 
@@ -623,22 +623,22 @@ A library authority or institution.
 |------------|----------------------------|------------|---------|------------|--------------------------------|
 | **E14D01** | **Authority/institution identifier** |  | **1**[4](#Notes)                                                    | **String** | **The LCF entity identifier used when referring to this authority/institution.**.               |
 | *E14C02*   | *Additional identifier*    |           | 0-n     |            | Composite element containing details of an additional identifier for this authority or institution                                                     |
-| E14D02.1   | Identifier type            |           | 1        | Code       | LCF code list **[INS](LCF-CodeLists#INS)**<br/>The identification scheme.                                                                   |
+| E14D02.1   | Identifier type            |           | 1        | Code       | LCF code list **[INS](LCF-CodeLists.md#INS)**<br/>The identification scheme.                                                                   |
 | E14D02.2   | Identifier type name       |           | 0-1      | String     | If the identification scheme is proprietary, the name of the scheme.                                                                           |
 | E14D02.3   | Identifier value           |           | 1        | String     | The identifier string.         |
 | **E14D03** | **Authority / institution name** |     | **1**    | **String** | **The name of this authority/institution**                                                                                        |
 | *E14C04*   | *Associated location*      |           | 0-n      |            | A location associated with this authority/institution.                                                                                         |
-| E14D04.1   | Location association type  |           | 1        | Code       | LCF code list **[LAT](LCF-CodeLists#LAT)**          |
+| E14D04.1   | Location association type  |           | 1        | Code       | LCF code list **[LAT](LCF-CodeLists.md#LAT)**          |
 | E14D04.2   | Location reference         |           | 1        | String     |                                |
 | *E14C05*   | *Associated contact*       |           | 0-n      |            | A contact associated with this authority/institution.                                                                                         |
-| E14D05.1   | Contact association type   |           | 1        | Code       | LCF code list **[CAT](LCF-CodeLists#CAT)**          |
+| E14D05.1   | Contact association type   |           | 1        | Code       | LCF code list **[CAT](LCF-CodeLists.md#CAT)**          |
 | E14D05.2   | Contact name               |           | 1        | String     |                                |
 | E14D05.3   | Contact reference          |           | 1        | String     |                                |
 | *E14C06*   | *Associated authority/institution* |   | 0-n      |            | Another authority/institution associated with this authority/institution.                                                                    |
-| E14D06.1   | Authority/institution association type | | 1      | Code       | LCF code list **[AAT](LCF-CodeLists#AAT)**          |
+| E14D06.1   | Authority/institution association type | | 1      | Code       | LCF code list **[AAT](LCF-CodeLists.md#AAT)**          |
 | E14D06.2   | Authority/institution reference |      | 1        | String     |                                |
 | *E14C07*   | *Authority/institution description / note* || 0-n |            |                                |
-| E14D07.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| E14D07.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E14D07.2   | Note date-time             |            | 0-1     | DateTime   |                                |
 | E14D07.3   | Note text                  |            | 1       | String     |                                |
 
@@ -657,20 +657,20 @@ A message or alert that may be communicated to a patron or group of patrons.
 |------------|----------------------------|------------|---------|------------|--------------------------------|
 | **E15D01** | **Message/alert identifier** |  | **1**[4](#Notes)                                                    | **String** | **The LCF entity identifier used when referring to this message/alert.**.                       |
 | E15D02     | Associated authority/institution |      | 0-1     | String     |                                |
-| **E15D03** | **Message/alert type**     |            | **1**   | **Code**   | LCF code list **[MAT](LCF-CodeLists#MAT)**                                                                                                  |
-| E15D04     | Message/alert priority     |            | 0-1     | Code       | LCF code list **[MAP](LCF-CodeLists#MAP)**                                                                                                  |
-| E15D05     | Message/alert display type |            | 0-1     | Code       | LCF code list **[MGT](LCF-CodeLists#MGT)**                                                                                                  |
-| E15D06     | Display/delivery constraint |          | 0-1     | Code       | LCF code list **[MAC](LCF-CodeLists#MAC)**                                                                                                  |
+| **E15D03** | **Message/alert type**     |            | **1**   | **Code**   | LCF code list **[MAT](LCF-CodeLists.md#MAT)**                                                                                                  |
+| E15D04     | Message/alert priority     |            | 0-1     | Code       | LCF code list **[MAP](LCF-CodeLists.md#MAP)**                                                                                                  |
+| E15D05     | Message/alert display type |            | 0-1     | Code       | LCF code list **[MGT](LCF-CodeLists.md#MGT)**                                                                                                  |
+| E15D06     | Display/delivery constraint |          | 0-1     | Code       | LCF code list **[MAC](LCF-CodeLists.md#MAC)**                                                                                                  |
 | E15D07     | Display from date-time     |            | 0-1     | DateTime   |                                |
 | E15D08     | Display until date-time    |            | 0-1     | DateTime   |                                |
-| E15D09     | Message/alert audience     |            | 0-1     | Code       | LCF code list **[MAU](LCF-CodeLists#MAU)**                                                                                                  |
+| E15D09     | Message/alert audience     |            | 0-1     | Code       | LCF code list **[MAU](LCF-CodeLists.md#MAU)**                                                                                                  |
 | E15D10     | Patron category            |            | 0-n     | String     | Only included if audience is not all patrons |
 | E15D11     | Patron reference           |            | 0-n     | String     | Only included if audience is not all patrons |
 | ***E15C12***  | **Message/alert text**  |            | **1-n** |            | Repeatable if the message/alert text is available in several alternative text formats                                                               |
-| **E15D12.1**  | Text format             |            | **1**   | Code       | LCF code list **[TFT](LCF-CodeLists#TFT)**                                                                                                  |
+| **E15D12.1**  | Text format             |            | **1**   | Code       | LCF code list **[TFT](LCF-CodeLists.md#TFT)**                                                                                                  |
 | **E15D12.2**  | Text string             |            | **1**   | String     |                                |
 | *E15C13*      | *Message/alert description / note* | | 0-n     |            |                                |
-| E15D13.1      | Note type                  |         | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| E15D13.1      | Note type                  |         | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E15D13.2      | Note date-time             |         | 0-1     | DateTime   |                                |
 | E15D13.3      | Note text                  |         | 1       | String     |                                |
 
@@ -687,17 +687,17 @@ The following data elements and composites are typically used for control of mes
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
 | *Q00C01*   | *User ID*                  | CN         | 0-1     |           | Composite element.              |
-| Q00D01.1   | Encryption algorithm       |            | 0-1     | Code      | LCF code list **[ECR](LCF-CodeLists#ECR)**<br/>The specific encryption algorithm, if any, employed by the terminal application for encrypting the user ID. If omitted, the string value may or may not be encrypted.                                                                  |
+| Q00D01.1   | Encryption algorithm       |            | 0-1     | Code      | LCF code list **[ECR](LCF-CodeLists.md#ECR)**<br/>The specific encryption algorithm, if any, employed by the terminal application for encrypting the user ID. If omitted, the string value may or may not be encrypted.                                                                  |
 | Q00D01.2   | String value               |            | 1       | String    | The encrypted or unencrypted string. Element Q00D01.1 may indicate the encryption algorithm employed, if any. Mandatory in each composite.          |
 | *Q00C02*   | *Password*                 | CO         | 0-1     |           | Composite element. It would be unusual for the password not to be encrypted.                                                                  |
-| Q00D02.1   | Encryption algorithm       |            | 0-1     | Code      | LCF code list **[ECR](LCF-CodeLists#ECR)**<br/>The specific encryption algorithm, if any, employed by the terminal application for encrypting the password. If omitted, the string value may or may not be encrypted.                                                                  |
+| Q00D02.1   | Encryption algorithm       |            | 0-1     | Code      | LCF code list **[ECR](LCF-CodeLists.md#ECR)**<br/>The specific encryption algorithm, if any, employed by the terminal application for encrypting the password. If omitted, the string value may or may not be encrypted.                                                                  |
 | Q00D02.2   | String value               |            | 1       | String    | The encrypted or unencrypted string. Element Q00D02.1 may indicate the encryption algorithm employed, if any. Mandatory in each composite.          |
 | Q00D03     | Institution identifier     | AO         | 0-1     | String    | LMS identifier for the institution, if terminals may be in one of several institutions.                                                            |
 | *Q00C04*   | *Terminal ID*              |            | 0-1     | String    | LMS identifier for the device or terminal on which the terminal application is running.                                                         |
-| Q00D04.1   | Encryption algorithm       |            | 0-1     | Code      | LCF code list **[ECR](LCF-CodeLists#ECR)**<br/>The specific encryption algorithm, if any, employed by the terminal application for encrypting the terminal ID. If omitted, the string value may or may not be encrypted.                                                         |
+| Q00D04.1   | Encryption algorithm       |            | 0-1     | Code      | LCF code list **[ECR](LCF-CodeLists.md#ECR)**<br/>The specific encryption algorithm, if any, employed by the terminal application for encrypting the terminal ID. If omitted, the string value may or may not be encrypted.                                                         |
 | Q00D04.2   | String value               |            | 1       | String    | The encrypted or unencrypted string. Element Q00D04.1 may indicate the encryption algorithm employed, if any. Mandatory in each composite.          |
 | *Q00C05*   | *Terminal password*        |            | 0-1     |           |                                 |
-| Q00D05.1   | Encryption algorithm       |            | 0-1     | Code      | LCF code list **[ECR](LCF-CodeLists#ECR)**           |
+| Q00D05.1   | Encryption algorithm       |            | 0-1     | Code      | LCF code list **[ECR](LCF-CodeLists.md#ECR)**           |
 | Q00D05.2   | String value               |            | 1       | String    | The encrypted or unencrypted string.|
 | Q00D06     | Terminal location reference| CP         | 0-1     | String    | The identifier for the location of the device or terminal on which the terminal application is running.                                           |
 | Q00D07     | Request ID                 |            | 0-1     | String    | An ID of a request. If included in a request, it must also be included in the LMS response.                                                         |
@@ -711,15 +711,15 @@ The following data elements and composites are typically used for control of mes
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
 | R00D01     | Response ID                |            | 0-1     | String    | An ID of a response.            |
-| R00D02     | Response type              |            | 0-1     | Code      | LCF code list **[RST](LCF-CodeLists#RST)**               |
+| R00D02     | Response type              |            | 0-1     | Code      | LCF code list **[RST](LCF-CodeLists.md#RST)**               |
 | R00D03     | Request reference          |            | 0-1     | String    | The ID of the request to which this is the response. Mandatory if the request included a request ID.                                               |
 | R00D04     | Response date-time         |            | 0-1     | DateTime  | The date and time of the response.|
 | *R00C05*   | *Exception condition*      |            | 0-n     |           | Response if there is an exception condition, in which case this and, optionally, one or more of the following message elements terminate the response.|
-| R00D05.1   | Condition type             |            | 1       | Code      | LCF code list **[EXC](LCF-CodeLists#EXC)**<br/>Response code will often be specific to the function requested.                                                         |
-| R00D05.2   | Reason request denied      |            | 0-1     | Code      | LCF code list **[RDN](LCF-CodeLists#RDN)**<br/>Used if R00D05.1 contains ''08' (request denied)                                                                       |
+| R00D05.1   | Condition type             |            | 1       | Code      | LCF code list **[EXC](LCF-CodeLists.md#EXC)**<br/>Response code will often be specific to the function requested.                                                         |
+| R00D05.2   | Reason request denied      |            | 0-1     | Code      | LCF code list **[RDN](LCF-CodeLists.md#RDN)**<br/>Used if R00D05.1 contains ''08' (request denied)                                                                       |
 | R00D05.3   | Element reference          |            | 0-1     | String    | A reference (e.g. the LCF element ID) that uniquely identifies the element in the request payload that generated the exception condition.            |
 | *R00C06*   | *Response message*         | AF / AG    | 0-n     |           | Composite element containing text to display or print on terminal.                                                                                  |
-| R00D06.1   | Message display type       |            | 1       | Code      | LCF code list **[MGT](LCF-CodeLists#MGT)**           |
+| R00D06.1   | Message display type       |            | 1       | Code      | LCF code list **[MGT](LCF-CodeLists.md#MGT)**           |
 | R00D06.2   | Message to display         |            | 1-n     | String    | Repeatable if display type is ‘single line’                                                                                                          |
 
 Core functions
@@ -736,9 +736,9 @@ This function may be used to retrieve information about an instance of an entity
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **Q01D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists#ENT)<br/>The entity type of the item about which information is requested. Information may be requested for any of the entity types E01 to E12 defined above.**                                                                                        |
+| **Q01D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists.md#ENT)<br/>The entity type of the item about which information is requested. Information may be requested for any of the entity types E01 to E12 defined above.**                                                                                        |
 | **Q01D02** | **Entity instance identifier** | **\*** | **1**   | **String**| **The primary (LMS) identifier for the entity instance.**                                                                                         |
-| Q01D03     | Requested item detailed information |   | 0-n     | Code      | LCF code list **[MND\|LCF-CodeLists#MND]]**, **[IMD](LCF-CodeLists#IMD)** or **[[PNT](LCF-CodeLists#PNT)**, depending upon entity type specified in Q01D01.<br/>Indicates the type of information to be included in the response. May be repeated if several types of information are requested, unless the code indicates that all details are to be included. If omitted, the details to be included are determined by the LMS.                          |
+| Q01D03     | Requested item detailed information |   | 0-n     | Code      | LCF code list **[MND\|LCF-CodeLists.md#MND]]**, **[IMD](LCF-CodeLists.md#IMD)** or **[[PNT](LCF-CodeLists.md#PNT)**, depending upon entity type specified in Q01D01.<br/>Indicates the type of information to be included in the response. May be repeated if several types of information are requested, unless the code indicates that all details are to be included. If omitted, the details to be included are determined by the LMS.                          |
 
 \* The correspondence with a SIP2 element depends upon the entity type. For entity types 'patron' and 'item' the correspondence is with SIP2 elements AA and AB respectively. The only other entity type that is likely to be specified with any frequency is ‘manifestation’.
 
@@ -759,11 +759,11 @@ This function may be used to retrieve a list of entity instances, with or withou
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **Q02D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists#ENT)<br/>The entity type of the item about which information is requested. Information may be requested for any of the entity types E01 to E12 defined above.**                                                                                        |
+| **Q02D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists.md#ENT)<br/>The entity type of the item about which information is requested. Information may be requested for any of the entity types E01 to E12 defined above.**                                                                                        |
 | *Q02C02*   | *Selection criterion*      |            | 0-n     |           | A criterion for selecting instances to be retrieved. If multiple selection criteria are specified, all must apply to all items retrieved. If no selection criteria are specified, all items of the specified entity type are to be included in the list.       |
-| Q02D02.1   | Selection criterion code   |            | 0-1     | String    | LCF Code list **[SEL](LCF-CodeLists#SEL)**<br/>*Changed in v1.0.1*                                                                                                        |
+| Q02D02.1   | Selection criterion code   |            | 0-1     | String    | LCF Code list **[SEL](LCF-CodeLists.md#SEL)**<br/>*Changed in v1.0.1*                                                                                                        |
 | Q02D02.2   | Criterion value            |            | 1       | String    |                                 |
-| Q02D03     | Requested instance detailed information | | 0-n   | Code      | LCF code list **[MND\|LCF-CodeLists#MND]]**, **[IMD](LCF-CodeLists#IMD)** or **[[PNT](LCF-CodeLists#PNT)**, depending upon entity type specified in Q02D01.<br/>Indicates the type of information to be included in the response. May be repeated if several types of information are requested, unless the code indicates that all details are to be included. If omitted, minimal details are included as determined by the LMS.                         |
+| Q02D03     | Requested instance detailed information | | 0-n   | Code      | LCF code list **[MND\|LCF-CodeLists.md#MND]]**, **[IMD](LCF-CodeLists.md#IMD)** or **[[PNT](LCF-CodeLists.md#PNT)**, depending upon entity type specified in Q02D01.<br/>Indicates the type of information to be included in the response. May be repeated if several types of information are requested, unless the code indicates that all details are to be included. If omitted, minimal details are included as determined by the LMS.                         |
 | Q02D04     | Requested maximum number of instances in response | | 0-1 | Positive integer | If present, the maximum number of instances from the list matching the specified selection criteria that are desired in the response. If not present, the entire list of instances matching the specified selection criteria should be included in the response. Responses should, wherever possible, honour this maximum when requested.                      |
 | Q02D05     | Index, in the complete list of instances found, of first instance in the response                                  |            | 0-1     | Positive integer or zero | If present, the desired index of the first instance in the response in the list of instances that match the specified selection criteria. For example, an offset value ‘10’ would imply that the first instance in the response should be the eleventh instance in the list. Responses should, wherever possible, honour this index when requested.          |
 
@@ -771,9 +771,9 @@ This function may be used to retrieve a list of entity instances, with or withou
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| R02D01     | Entity type                |            | 0-1     | Code      | LCF code list **[ENT](LCF-CodeLists#ENT)**<br/>Mandatory if the number of instances in the response is greater than zero.                                               |
+| R02D01     | Entity type                |            | 0-1     | Code      | LCF code list **[ENT](LCF-CodeLists.md#ENT)**<br/>Mandatory if the number of instances in the response is greater than zero.                                               |
 | *R02C02*   | *Selection criterion*      |            | 0-n     |           | A criterion used for selecting instances, as specified in the request. It is recommended that if selection criteria are included in the request, they should also be included in the response for reference purposes.                                           |
-| R02D02.1   | Selection criterion code   |            | 1       | Code      | LCF Code list **[SEL](LCF-CodeLists#SEL)**<br/>*Changed in v1.0.1*                                                                                                        |
+| R02D02.1   | Selection criterion code   |            | 1       | Code      | LCF Code list **[SEL](LCF-CodeLists.md#SEL)**<br/>*Changed in v1.0.1*                                                                                                        |
 | R02D02.2   | Criterion value            |            | 1       | String    |                                 |
 | R02D03     | Number of instances in the list matching the selection criteria specified in the request                                   |            | 0-1     | Positive integer |                          |
 | R02D04     | Number of instances in this response |  | 0-1     | Positive integer |                          |
@@ -792,14 +792,14 @@ This function is used to create a new item of a specific entity type. In practic
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **Q03D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists#ENT)<br/>The entity type of the item to be created.**                                                                              |
+| **Q03D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists.md#ENT)<br/>The entity type of the item to be created.**                                                                              |
 |            | Other elements, excluding the LCF entity identifier, as determined by the specified entity type – see E01 to E12 above                                 |            |         |           |                                 |
 
 #### Response
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **R03D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists#ENT)<br/>The entity type of the item created in response to the request.**                                                         |
+| **R03D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists.md#ENT)<br/>The entity type of the item created in response to the request.**                                                         |
 | **R03D02** | **Item identifier**        |            | **1**   | **String**| **The LCF entity identifier for the inventory item, assigned by the LMS if a new item has been successfully created.**                             |
 
 ***
@@ -813,16 +813,16 @@ This function is used to modify an existing item of a specific entity type.
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **Q04D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists#ENT)**           |
+| **Q04D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists.md#ENT)**           |
 | **Q04D02** | **Item identifier**        |            | **1**   | **String**| **The identifier of the item to be modified.**                                                                                                    |
-| **Q04D03** | **Modification type**      |            | **1**   | **Code**  | **LCF code list [MOT](LCF-CodeLists#MOT)**           |
+| **Q04D03** | **Modification type**      |            | **1**   | **Code**  | **LCF code list [MOT](LCF-CodeLists.md#MOT)**           |
 |            | Other elements as determined by the specified entity type – see E01 to E12 above                                     |            |         |           |                                 |
 
 #### Response
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **R04D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists#ENT)<br/>The entity type of the item created in response to the request.**                                                         |
+| **R04D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists.md#ENT)<br/>The entity type of the item created in response to the request.**                                                         |
 | **R04D02** | **Item identifier**        |            | **1**   | **String**| **The identifier for the item that has been successfully modified.**                                                                              |
 
 ***
@@ -836,14 +836,14 @@ This function is used to delete an item of a specific entity type. Since deletio
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **Q05D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists#ENT)**           |
+| **Q05D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists.md#ENT)**           |
 | **Q05D02** | **Item identifier**        |            | **1**   | **String**| **The identifier of the item to be deleted.**                                                                                                     |
 
 #### Response
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **R05D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists#ENT)<br/>The entity type of the item created in response to the request.**                                                         |
+| **R05D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists.md#ENT)<br/>The entity type of the item created in response to the request.**                                                         |
 | **R05D02** | **Item identifier**        |            | **1**   | **String**| **The identifier of the item that has been successfully deleted**                                                                                    |
 
 Circulation management functions
@@ -872,8 +872,8 @@ The terminal application must provide all the information required for all the n
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **Q11D01** | **Request type**           |            | **1**   | **Code**  | **LCF code list [RQT](LCF-CodeLists#RQT)<br/>Indicates type of check-out request.**                                                                                   |
-| Q11D02     | Renewal type               |            | 0-1     | Code      | LCF code list [RNQ](LCF-CodeLists#RNQ)<br/>Indicates that the request is a renewal request and which type                                                                |
+| **Q11D01** | **Request type**           |            | **1**   | **Code**  | **LCF code list [RQT](LCF-CodeLists.md#RQT)<br/>Indicates type of check-out request.**                                                                                   |
+| Q11D02     | Renewal type               |            | 0-1     | Code      | LCF code list [RNQ](LCF-CodeLists.md#RNQ)<br/>Indicates that the request is a renewal request and which type                                                                |
 | Q11D03     | Patron reference           | AA         | 0-1     | String    | Reference to the patron record. Mandatory in a new check-out.                                                                                  |
 | Q11D04     | Item reference             | AB         | 0-1     | String    | Reference to the item in question. Mandatory unless cancelling a check-out / renewal.                                                             |
 | Q11D05     | Loan reference             |            | 0-1     | String    | Mandatory when renewing or cancelling a check-out or renewal.                                                                                        |
@@ -886,8 +886,8 @@ The terminal application must provide all the information required for all the n
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
 | R11D01     | Loan reference             |            | 0-1     | String    | LCF entity identifier for loan. Either a loan reference, or a copy of the loan record must be included in the response.                        |
 | R11C02     | Loan entity record         |            | 0-1     |           | See E05                         |
-| R11D03     | Item sensitive media warning |          | 0-1     | Code      | LCF code list **[MEW](LCF-CodeLists#MEW)**<br/>Same as E02D07. Flag indicating that the item contains a media component that is sensitive to some security setting devices. Mandatory on a new check-out unless the loan entity record is included in the response.                        |
-| R11D04     | Desensitize item security  |            | 0-1     | Code      | LCF code list **[SCD](LCF-CodeLists#SCD)**<br/>Same as E02D08. Flag indicating whether the security should or should not be desensitized / removed on check-out. Mandatory on a new check-out unless the loan entity record is included in the response.                                  |
+| R11D03     | Item sensitive media warning |          | 0-1     | Code      | LCF code list **[MEW](LCF-CodeLists.md#MEW)**<br/>Same as E02D07. Flag indicating that the item contains a media component that is sensitive to some security setting devices. Mandatory on a new check-out unless the loan entity record is included in the response.                        |
+| R11D04     | Desensitize item security  |            | 0-1     | Code      | LCF code list **[SCD](LCF-CodeLists.md#SCD)**<br/>Same as E02D08. Flag indicating whether the security should or should not be desensitized / removed on check-out. Mandatory on a new check-out unless the loan entity record is included in the response.                                  |
 | R11D05     | Charge reference           |            | 0-1     | String    | Reference to charge created with this loan. |
 | R11D06     | Digital content access link |   | 0-1     | String    | Non-persistent link to be used by the patron to access checked-out digital content<br/>*Added v1.0.1*                                                |
 
@@ -908,7 +908,7 @@ The check-in function combines the following core functions:
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **Q12D01** | **Request type**           |            | **1**   | **Code**  | **LCF code list [RQT](LCF-CodeLists#RQT)**           |
+| **Q12D01** | **Request type**           |            | **1**   | **Code**  | **LCF code list [RQT](LCF-CodeLists.md#RQT)**           |
 | Q12D02     | Patron reference           | AA         | 0-1     | String    |                                 |
 | **Q12D03** | **Item reference**         | **AB**     | **0-1** | **String**|                                 |
 | Q12D04     | Loan reference             |            | 0-1     | String    |                                 |
@@ -922,8 +922,8 @@ The check-in function combines the following core functions:
 | R12D02     | Patron reference           | AA         | 0-1     | String    |                                 |
 | R12D03     | Item reference             | AB         | 0-1     | String    |                                 |
 | R12D04     | Item return location reference| CL      | 0-1     | String    | LCF entity identifier for return location, e.g. sort bin.                                                                                       |
-| R12D05     | Item sensitive media warning|           | 0-1     | Code      | LCF code list **[MEW](LCF-CodeLists#MEW)**<br/>Flag indicating that the item contains a media component that is sensitive to some security setting devices.        |
-| R12D06     | Item requires special attention|        | 0-1     | Code      | LCF code list **[SPA](LCF-CodeLists#SPA)**<br/>Flag indicating that this item requires special attention before it is returned to its shelf location.              |
+| R12D05     | Item sensitive media warning|           | 0-1     | Code      | LCF code list **[MEW](LCF-CodeLists.md#MEW)**<br/>Flag indicating that the item contains a media component that is sensitive to some security setting devices.        |
+| R12D06     | Item requires special attention|        | 0-1     | Code      | LCF code list **[SPA](LCF-CodeLists.md#SPA)**<br/>Flag indicating that this item requires special attention before it is returned to its shelf location.              |
 | R12D07     | Special attention description|          | 0-1     | String    | Description of special attention required, if any.                                                                                              |
 | R12D08     | Charge reference           |            | 0-n     | String    | LCF entity identifier of any charge due on this item. Repeatable if more than one charge is due (e.g. loan fee and overdue fine).                  |
 
@@ -940,10 +940,10 @@ The patron payment function combines the following core functions:
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **Q13D01** | **Request type**           |            | **1**   | **Code**  | **LCF code list [RQT](LCF-CodeLists#RQT)** |
+| **Q13D01** | **Request type**           |            | **1**   | **Code**  | **LCF code list [RQT](LCF-CodeLists.md#RQT)** |
 | **Q13D02** | **Patron reference**       | **AA**     | **1**   | **String**|                                 |
 | Q13D03     | Charge reference           |            | 0-n     | String    | Charge(s) against which to set this payment. If omitted, the LMS determines the charges against which to set the payment.                          |
-| **Q13D04** | **Payment type**           |            | **1**   | **Code**  | **LCF code list [PYT](LCF-CodeLists#PYT)**           |
+| **Q13D04** | **Payment type**           |            | **1**   | **Code**  | **LCF code list [PYT](LCF-CodeLists.md#PYT)**           |
 | Q13D05     | Payment type description   |            | 0-1     | String    | Further information on method of payment                                                                                                        |
 | **Q13D06** | **Payment amount**         |            | **1**   | **Value** | **Currency value.**             |
 | Q13D07     | Payment currency           |            | 0-1     | Code      | ISO three-letter currency code, e.g. ‘GBP’                                                                                                          |
@@ -968,7 +968,7 @@ Used to prevent unauthorised use of a patron account, such as when the patron’
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
 | **Q14D01** | **Patron reference**       | **AA**     | **1**   | **String**|                                 |
-| Q14D02     | Library card status        |            | 0-1     | Code      | LCF code list **[PCS](LCF-CodeLists#PCS)**           |
+| Q14D02     | Library card status        |            | 0-1     | Code      | LCF code list **[PCS](LCF-CodeLists.md#PCS)**           |
 | Q14D03     | Blocked card message       | AL         | 0-1     | String    |                                 |
 
 #### Response
@@ -1017,11 +1017,11 @@ The reserve function combines the following core functions:
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **Q16D01** | **Request type**           | **BX / BI**| **1**   | **Code**  | **LCF code list [RQT](LCF-CodeLists#RQT)**           |
+| **Q16D01** | **Request type**           | **BX / BI**| **1**   | **Code**  | **LCF code list [RQT](LCF-CodeLists.md#RQT)**           |
 | **Q16D02** | **Patron reference**       | **AA**     | **1**   | **String**|                                 |
-| **Q16D03** | **Item entity type**       |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists#ENT) – only code values '01' and '02' are valid**                                                                               |
+| **Q16D03** | **Item entity type**       |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists.md#ENT) – only code values '01' and '02' are valid**                                                                               |
 | **Q16D04** | **Item reference**         | **AB**     | **1**   | **String**|                                 |
-| Q16D05     | Reservation type           | BY         | 0-1     | Code      | LCF code list **[RVT](LCF-CodeLists#RVT)**           |
+| Q16D05     | Reservation type           | BY         | 0-1     | Code      | LCF code list **[RVT](LCF-CodeLists.md#RVT)**           |
 | Q16D06     | Pick-up institution reference| AO       | 0-1     | String    | The LCF entity identifier of the branch library or other institution where the items are to be picked up by the patron. Normally only included if the reservation type is ‘04’.                                                                                      |
 | Q16D07     | Pick-up location reference | BS         | 0-1     | String    | The LCF entity identifier of the location where the items are to be picked up by the patron. Normally only included if the reservation type is ‘04’, either instead of or additional to Q16D06.                                                                     |
 | Q16D08     | Reservation start date     |            | 0-1     | DateTime  | Only used in confirmations.     |
@@ -1103,15 +1103,15 @@ The function applies the following core function:
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **Q31D01** | **Request type**           | **BX / BI**| **1**   | **Code**  | **LCF code list [RQT](LCF-CodeLists#RQT)**           |
-| **Q31D02** | **Charge type**            | **BT**     | **1**   | **Code**  | **LCF code list [CHT](LCF-CodeLists#CHT)**           |
-| **Q31D03** | **Charge status**          |            | **1**   | **Code**  | **LCF code list [CHS](LCF-CodeLists#CHS)**           |
+| **Q31D01** | **Request type**           | **BX / BI**| **1**   | **Code**  | **LCF code list [RQT](LCF-CodeLists.md#RQT)**           |
+| **Q31D02** | **Charge type**            | **BT**     | **1**   | **Code**  | **LCF code list [CHT](LCF-CodeLists.md#CHT)**           |
+| **Q31D03** | **Charge status**          |            | **1**   | **Code**  | **LCF code list [CHS](LCF-CodeLists.md#CHS)**           |
 | **Q31D04** | **Patron reference**       | **AA**     | **1**   | **String**|                                 |
 | Q31D05     | Payment due date-time      |            | 0-1     | DateTime  | The date and optionally time on which the charge becomes due for payment.                                                                            |
 | **Q31D06** | **Gross charge amount**    | **BV**     | **1**   | **Value** | **Currency value of original charge**|
 | Q31D07     | Charge currency            | BH         | 0-1     | Code      | ISO three-letter currency code, e.g. ‘GBP’                                                                                                          |
 | *Q31C08*   | *Charge note*              |            | 0-n     |            | A note attached to this charge.|
-| Q31D08.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists#NOT)**          |
+| Q31D08.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | Q31D08.2   | Note date-time             |            | 0-1     | DateTime   |                                |
 | Q31D08.3   | Note text                  |            | 1       | String     |                                |
 

--- a/docs/LCF-InformationEntityXMLBindings.md
+++ b/docs/LCF-InformationEntityXMLBindings.md
@@ -42,24 +42,24 @@ E01 MANIFESTATION
 | **1**  |              | **manifestation<br/>xmlns=<br/>"http://ns.bic.org/lcf/1.0"**                                       |         |             | **Top-level&nbsp;element**<br/>*'version' attribute removed in v1.0.1*                                 |
 |   2    | E01D01       | identifier                       | 0-1     | string      | Mandatory except when creating a new entity, in which case the identifier may be assigned by the LMS                        |
 |   3    | E01C02       | additional-manifestation-id      | 0-n     |             |         |
-|   4    | E01D02.1     | manifestation-id-type            | 1       | Code        | [MNI](LCF-CodeLists#MNI)     |
+|   4    | E01D02.1     | manifestation-id-type            | 1       | Code        | [MNI](LCF-CodeLists.md#MNI)     |
 |   5    | E01D02.2     | type-name                        | 0-1     | string      |         |
 |   6    | E01D02.3     | value                            | 1       | string      |         |
 |   7    | E01C03       | media-type                       | 0-n     |             |         |
-|   8    | E01D03.1     | media-type-scheme                | 1       | Code        | [MES](LCF-CodeLists#MES)     |
+|   8    | E01D03.1     | media-type-scheme                | 1       | Code        | [MES](LCF-CodeLists.md#MES)     |
 |   9    | E01D03.2     | scheme-name                      | 0-1     | string      |         |
 |  10    | E01D03.3     | scheme-code                      | 1       | string      |         |
 |  11    | E01C04       | title                            | 0-n     |             |         |
-|  12    | E01D04.1     | title-type                       | 1       | Code        | [TTL](LCF-CodeLists#TTL)     |
+|  12    | E01D04.1     | title-type                       | 1       | Code        | [TTL](LCF-CodeLists.md#TTL)     |
 |  13    | E01D04.2     | title-text                       | 1       | string      |         |
 |  14    | E01D04.3     | subtitle                         | 0-1     | string      |         |
 |  15    | E01C05       | contributor                      | 0-n     |             |         |
 |  16    | E01D05.1     | contributor-role                 | 1       | Code        | ONIX code list 17                                                                                           |
 |  17    | E01D05.2     | contributor-name                 | 0-1     | string      | Either a contributor name or an unnamed contributor code must be included in each contributor composite.                     |
-|  18    | E01D05.3     | unnamed-contributor              | 0-1     | Code        | [UNC](LCF-CodeLists#UNC)     |
+|  18    | E01D05.3     | unnamed-contributor              | 0-1     | Code        | [UNC](LCF-CodeLists.md#UNC)     |
 |  19    | E01C06       | series                           | 0-1     |             |         |
 |  20    | E01C06.1     | title                            | 0-n     |             |         |
-|  21    | E01D06.1.1   | title-type                       | 1       | Code        | [TTL](LCF-CodeLists#TTL)     |
+|  21    | E01D06.1.1   | title-type                       | 1       | Code        | [TTL](LCF-CodeLists.md#TTL)     |
 |  22    | E01D06.1.2   | title-text                       | 1       | string      |         |
 |  23    | E01D06.1.3   | subtitle                         | 0-1     | string      |         |
 |  24    | E01D06.2     | volume-or-part                   | 0-1     | string      |         |
@@ -73,21 +73,21 @@ E01 MANIFESTATION
 |  32    | E01D11       | cover-art                        | 0-n     | anyURI      |         |
 |  33    | E01D12       | description                      | 0-1     | string      |         |
 |  34    | E01C13       | loan-restriction                 | 0-n     |             |         |
-|  35    | E01D13.1     | restriction-type                 | 1       | Code        | [CRT](LCF-CodeLists#CRT)     |
+|  35    | E01D13.1     | restriction-type                 | 1       | Code        | [CRT](LCF-CodeLists.md#CRT)     |
 |  36    | E01D13.2     | value                            | 1       | string      |         |
 |  37    | E01D13.3     | note                             | 0-1     | string      |         |
 |  38    | E01C14       | loan-fee                         | 0-n     |             |         |
-|  39    | E01D14.1     | fee-type                         | 1       | Code        | [CHT](LCF-CodeLists#CHT)     |
+|  39    | E01D14.1     | fee-type                         | 1       | Code        | [CHT](LCF-CodeLists.md#CHT)     |
 |  40    | E01D14.2     | amount                           | 1       | decimal     |         |
 |  41    | E01D14.3     | currency                         | 0-1     | Code        | ISO 3-letter code                                                                                         |
 |  42    | E01D15       | patrons-in-hold-queue            |0-1R[1](#Notes)                                                 | int         |         |
 |  43    | E01D16       | manifestation-record             | 0-1     | string      | *Renamed in v1.0.1* |
-| **44** | **E01D17**   | **manifestation-status**         | **1**   | **Code**    | **[MNS](LCF-CodeLists#MNS)** |
+| **44** | **E01D17**   | **manifestation-status**         | **1**   | **Code**    | **[MNS](LCF-CodeLists.md#MNS)** |
 |  45    | E01D18       | items-in-stock                   | 0-1R    | int         |         |
 |  46    | E01D19       | item-ref                         | 0-nR    | string      |         |
 |  47    | E01D20       | reservation-ref                  | 0-nR    | string      |         |
 |  48    | E01C21       | note                             | 0-n     |             |         |
-|  49    | E01D21.1     | note-type                        | 0-1     | Code        | [NOT](LCF-CodeLists#NOT)     |
+|  49    | E01D21.1     | note-type                        | 0-1     | Code        | [NOT](LCF-CodeLists.md#NOT)     |
 |  50    | E01D21.2     | date-time                        | 0-1     | dateTime    |         |
 |  51    | E01D21.3     | note-text                        | 1       | string      |         |
 
@@ -118,33 +118,33 @@ E02 ITEM
 | **1**  |              | **item<br/>xmlns=<br/>"http://ns.bic.org/lcf/1.0"**                                         |        |              | **Top-level&nbsp;element**<br/>*'version' attribute removed in v1.0.1*                                |
 |   2    | E02D01       | identifier                  | 0-1     | string      | Mandatory except when creating a new entity, in which case the identifier may be assigned by the LMS                         |
 |   3    | E02C02       | additional-item-id          | 0-n     |             |         |
-|   4    | E02D02.1     | item-id-type                | 1       | Code        | [IMI](LCF-CodeLists#IMI)     |
+|   4    | E02D02.1     | item-id-type                | 1       | Code        | [IMI](LCF-CodeLists.md#IMI)     |
 |   5    | E02D02.2     | type-name                   | 0-1     | string      |         |
 |   6    | E02D02.3     | value                       | 1       | string      |         |
 | **7**  | **E02D03**   | **manifestation-ref**       | **1**   | **string**  |         |
 |   8    | E02D04       | description                 | 0-1     | string      |         |
 |   9    | E02D05       | owner-ref                   | 0-1     | string      | *Tag name changed from 'owner' to 'owner-ref' in v1.0.1. References an Authority/Institution entity (E14)*                |
 |  10    | E02C06       | associated-location         | 0-n     |             |         |
-|  11    | E02D06.1     | association-type            | 1       | Code        | [LAT](LCF-CodeLists#LAT)     |
+|  11    | E02D06.1     | association-type            | 1       | Code        | [LAT](LCF-CodeLists.md#LAT)     |
 |  12    | E02D06.2     | location-ref                | 1       | string      | *Cardinality corrected in v1.0.1*                                                                                 |
-|**13**  | **E02D07**   | **media-warning**           | **1**   | **Code**    | **[MEW](LCF-CodeLists#MEW)** |
-|**14**  | **E02D08**   | **security-desensitize**    | **1**   | **Code**    | **[SCD](LCF-CodeLists#SCD)** |
+|**13**  | **E02D07**   | **media-warning**           | **1**   | **Code**    | **[MEW](LCF-CodeLists.md#MEW)** |
+|**14**  | **E02D08**   | **security-desensitize**    | **1**   | **Code**    | **[SCD](LCF-CodeLists.md#SCD)** |
 |  15    | E02C09       | loan-restriction            | 0-n     |             |         |
-|  16    | E02D09.1     | restriction-type            | 1       | Code        | [CRT](LCF-CodeLists#CRT)     |
+|  16    | E02D09.1     | restriction-type            | 1       | Code        | [CRT](LCF-CodeLists.md#CRT)     |
 |  17    | E02D09.2     | value                       | 1       | string      |         |
 |  18    | E02D09.3     | note                        | 0-1     | string      |         |
 |  19    | E02C10       | loan-fee                    | 0-n     |             |         |
-|  20    | E02D10.1     | fee-type                    | 1       | Code        | [CHT](LCF-CodeLists#CHT)     |
+|  20    | E02D10.1     | fee-type                    | 1       | Code        | [CHT](LCF-CodeLists.md#CHT)     |
 |  21    | E02D10.2     | amount                      | 1       | decimal     |         |
 |  22    | E02D10.3     | currency                    | 0-1     | Code        | ISO 3-letter code                                                                                    |
-|**23**  | **E02D11**   | **circulation-status**      | **1**   | **Code**    | **[CIS](LCF-CodeLists#CIS)** |
+|**23**  | **E02D11**   | **circulation-status**      | **1**   | **Code**    | **[CIS](LCF-CodeLists.md#CIS)** |
 |  24    | E02D12       | reservation-ref             | 0-nR    | string      |         |
 |  25    | E02D13       | patrons-in-hold-queue       | 0-1R    | int         |         |
 |  26    | E02D14       | on-loan-ref                 | 0-1R    | string      |         |
 |  27    | E02D15       | condition-code              | 0-1     | Code        | LMS-proprietary                                                                         |
 |  28    | E02D16       | condition-description       | 0-1     | string      |         |
 |  29    | E02C17       | note                        | 0-n     |             |         |
-|  30    | E02D17.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists#NOT)     |
+|  30    | E02D17.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists.md#NOT)     |
 |  31    | E02D17.2     | date-time                   | 0-1     | dateTime    |         |
 |  32    | E02D17.3     | note-text                   | 1       | string      |         |
 
@@ -167,26 +167,26 @@ E03 PATRON
 |   2   | E03D01       | identifier                  | 0-1     | string      | Mandatory except when creating a new entity, in which case the identifier may be assigned by the LMS                        |
 |   3   | E03D26       | barcode-id                  | 0-1     | String      | *Added v1.0.1*                 |
 |   4   | E03C27       | additional-patron-id        | 0-n     |             | *Added v1.0.1*                 |
-|   5   | E03D27.1     | patron-id-type              | 1       | Code        | **[PNI](LCF-CodeLists#PNI)** |
+|   5   | E03D27.1     | patron-id-type              | 1       | Code        | **[PNI](LCF-CodeLists.md#PNI)** |
 |   6   | E02D27.2     | type-name                   | 0-1     | String      |         |
 |   7   | E02D27.3     | value                       | 1       | String      |         |
 | **8** | **E03D22**   | **name**                    | **1**   | **string**  | *Added v1.0.1*                 |
 |   9   | E03D02       | contact-ref                 | 0-n     | string      |         |
 |  10   | E03D23       | language                    | 0-1     | Code        | ISO three-letter code<br/>*Added v1.0.1*                                                                                |
 |  11   | E03C03       | associated-location         | 0-n     |             |         |
-|  12   | E03D03.1     | association-type            | 1       | Code        | [LAT](LCF-CodeLists#LAT)    |
+|  12   | E03D03.1     | association-type            | 1       | Code        | [LAT](LCF-CodeLists.md#LAT)    |
 |  13   | E03D03.2     | location-ref                | 1       | string      | *Cardinality corrected in v1.0.1* |
 |  14   | E03D34       | home-institution-ref        | 0-1     | string      | *added v1.0.1*                 |
-|  15   | E03D04       | patron-status               | 0-nR    | Code        | [PNS](LCF-CodeLists#PNS)    |
+|  15   | E03D04       | patron-status               | 0-nR    | Code        | [PNS](LCF-CodeLists.md#PNS)    |
 |  16   | E03C24       | card-status-info            | 0-nR    |             | *Added v1.0.1*                 |
-|  17   | E03D24.1     | card-status                 | 1R      | Code        | [PCS](LCF-CodeLists#PCS)    |
+|  17   | E03D24.1     | card-status                 | 1R      | Code        | [PCS](LCF-CodeLists.md#PCS)    |
 |  18   | E03D24.2     | blocked-card-message        | 0-1R    | string      |         |
 |  19   | E03D28       | patron-category             | 0-1     | string      | *Added v1.0.1*                 |
 |  20   | E03D29       | patron-tag                  | 0-n     | string      | *Added v1.0.1*                 |
 |  21   | E03D32       | authorisation-code          | 0-n     | string      | *Added v1.0.1*                 |
 |  22   | E03D30       | patron-expiration-date      | 0-1     | date        | *Added v1.0.1*                 |
 |  23   | E03C33       | associated-patron-group     | 0-n     |             | *Added v1.0.1*                 |
-|  24   | E03D33.1     | association-type            | 1       | Code        | [PGP](LCF-CodeLists#PGP)    |
+|  24   | E03D33.1     | association-type            | 1       | Code        | [PGP](LCF-CodeLists.md#PGP)    |
 |  25   | E03D33.5     | group-type                  | 0-1     | String      |         |
 |  26   | E03D33.2     | patron-group-id             | 0-1     | String      |         |
 |  27   | E03D33.3     | lead-patron-ref             | 0-n     | String      |         |
@@ -205,7 +205,7 @@ E03 PATRON
 |  40   | E03D18       | hold-items-limit            | 0-1     | int         |         |
 |  41   | E03D19       | charge-ref                  | 0-nR    | string      |         |
 |  42   | E03C20       | charge-limit                | 0-n     |             |         |
-|  43   | E03D20.1     | charge-type                 | 0-1     | Code        | [CHT](LCF-CodeLists#CHT)   |
+|  43   | E03D20.1     | charge-type                 | 0-1     | Code        | [CHT](LCF-CodeLists.md#CHT)   |
 |  44   | E03D20.2     | amount                      | 1       | decimal     |         |
 |  45   | E03D20.3     | currency                    | 0-1     | Code        | ISO currency code             |
 |  46   | E03C31       | deposit-balance             | 0-1     | decimal     | *Added v1.0.1*                |
@@ -213,9 +213,9 @@ E03 PATRON
 |  48   | E03D31.2     | currency                    | 0-1     | Code        | ISO currency code             |
 |  49   | E03C34       | associated-message          | 0-n     |             |         |
 |  50   | E03D34.1     | message-ref                 | 1       | string      |         |
-|  51   | E03D34.2     | delivery-status             | 1       | Code        | [MAD](LCF-CodeLists#MAD)   |
+|  51   | E03D34.2     | delivery-status             | 1       | Code        | [MAD](LCF-CodeLists.md#MAD)   |
 |  52   | E03C21       | note                        | 0-n     |             |         |
-|  53   | E03D21.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists#NOT)   |
+|  53   | E03D21.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists.md#NOT)   |
 |  54   | E03D21.2     | date-time                   | 0-1     | dateTime    |         |
 |  55   | E03D21.3     | note-text                   | 1       | string      |         |
 |  56   | E03D25       | date-of-birth               | 0-1     | date        | *Added v1.0.1*                |
@@ -228,18 +228,18 @@ E04 LOCATION
 | **1** |              | **location<br/>xmlns=<br/>"http://ns.bic.org/lcf/1.0"**                                 |         |             | **Top-level&nbsp;element**<br/>*'version' attribute removed in v1.0.1*                                                        |
 |   2   | E04D01       | identifier                  | 0-1     | string      | Mandatory except when creating a new entity, in which case the identifier will be assigned by the LMS                       |
 |   3   | E04C02       | additional-location-id      | 0-n     |             |         |
-|   4   | E04D02.1     | location-id-type            | 1       | Code        | [LOI](LCF-CodeLists#LOI)     |
+|   4   | E04D02.1     | location-id-type            | 1       | Code        | [LOI](LCF-CodeLists.md#LOI)     |
 |   5   | E04D02.2     | type-name                   | 0-1     | string      |         |
 |   6   | E04D02.3     | value                       | 1       | string      |         |
 |   7   | E04D03       | name                        | 0-1     | string      |         |
-|   8   | E04D04       | location-type               | 0-1     | Code        | [LOT](LCF-CodeLists#LOT)     |
+|   8   | E04D04       | location-type               | 0-1     | Code        | [LOT](LCF-CodeLists.md#LOT)     |
 |   9   | E04D05       | description                 | 0-1     | string      |         |
 |  10   | E04D07       | contact-ref                 | 0-n     | string      | *Added v1.0.1*                  |
 |  11   | E04C08       | associated-location         | 0-n     |             |         |
-|  12   | E04D08.1     | association-type            | 1       | Code        | [LAT](LCF-CodeLists#LAT)    |
+|  12   | E04D08.1     | association-type            | 1       | Code        | [LAT](LCF-CodeLists.md#LAT)    |
 |  13   | E04D08.2     | location-ref                | 1       | string      |         |
 |  14   | E04C06       | note                        | 0-n     |             |         |
-|  15   | E04D06.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists#NOT)     |
+|  15   | E04D06.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists.md#NOT)     |
 |  16   | E04D06.2     | date-time                   | 0-1     | dateTime    |         |
 |  17   | E04D06.3     | note-text                   | 1       | string      |         |
 
@@ -255,16 +255,16 @@ E05 LOAN
 | **5** | **E05D04**   | **start-date**              | **1**   | **dateTime** |         |
 |   6   | E05D05       | end-due-date                | 0-1     | dateTime     |         |
 |   7   | E05D06       | end-date                    | 0-1     | dateTime     |         |
-| **8** | **E05D07**   | **loan-status**             | **1-n** | **Code**     | **[LOS](LCF-CodeLists#LOS)** |
+| **8** | **E05D07**   | **loan-status**             | **1-n** | **Code**     | **[LOS](LCF-CodeLists.md#LOS)** |
 |   9   | *E05C13*     | access-link                 | 0-n     |              | *Added v1.0.1*                  |
-|  10   | E05D13.1     | link-type                   | 1       | Code         | [LKT](LCF-CodeLists#LKT)    |
+|  10   | E05D13.1     | link-type                   | 1       | Code         | [LKT](LCF-CodeLists.md#LKT)    |
 |  11   | E05D13.2     | link                        | 1       | String       |         |
 |  12   | E05D08       | previous-loan-ref           | 0-1     | string       |         |
 |  13   | E05D09       | renewal-loan-ref            | 0-1R    | string       |         |
 |  14   | E05D10       | recall-notice-date          | 0-1R    | dateTime     |         |
 |  15   | E05D11       | charge-ref                  | 0-nR    | string       |         |
 |  16   | E05C12       | note                        | 0-n     |              |         |
-|  17   | E05D12.1     | note-type                   | 0-1     | Code         | [NOT](LCF-CodeLists#NOT)     |
+|  17   | E05D12.1     | note-type                   | 0-1     | Code         | [NOT](LCF-CodeLists.md#NOT)     |
 |  18   | E05D12.2     | date-time                   | 0-1     | dateTime     |         |
 |  19   | E05D12.3     | note-text                   | 1       | string       |         |
 
@@ -275,7 +275,7 @@ E06 RESERVATION
 |--------|--------------|-----------------------------|---------|-------------|---------|
 | **1**  |              | **reservation<br/>xmlns=<br/>"http://ns.bic.org/lcf/1.0"**                                  |         |             | **Top-level&nbsp;element**<br/>*'version' attribute removed in v1.0.1*                                                         |
 |   2    | E06D01       | identifier                  | 0-1     | string      | Mandatory except when creating a new entity, in which case the identifier will be assigned by the LMS                        |
-| **3**  | **E06D02**   | **reservation-type**        | **1**   | **Code**    | **[RVT](LCF-CodeLists#RVT)** |
+| **3**  | **E06D02**   | **reservation-type**        | **1**   | **Code**    | **[RVT](LCF-CodeLists.md#RVT)** |
 | **4**  | **E06D03**   | **patron-ref**              | **1**   | **string**  |         |
 |   5    | E06D04       | manifestation-ref           | 0-1     | string      | Either E06D04 or E06D05 must be included in each reservation instance                                                   |
 |   6    | E06D05       | item-ref                    | 0-1     | string      |         |
@@ -284,12 +284,12 @@ E06 RESERVATION
 |   9    | E06D08       | pickup-location-ref         | 0-1     | string      |         |
 |  10    | E06D09       | pickup-date                 | 0-1     | dateTime    |         |
 |  11    | E06D10       | end-date                    | 0-1     | dateTime    |         |
-|**12**  | **E06D11**   | **reservation-status**      | **1**   | **Code**    | **[RVS](LCF-CodeLists#RVS)** |
+|**12**  | **E06D11**   | **reservation-status**      | **1**   | **Code**    | **[RVS](LCF-CodeLists.md#RVS)** |
 |  13    | E06D15       | hold-queue-position         | 0-1     | int         | *Added in v1.0.1* |
 |  14    | E06D12       | loan-ref                    | 0-1R    | string      |         |
 |  15    | E06D13       | charge-ref                  | 0-nR    | string      |         |
 |  16    | E06C14       | note                        | 0-n     |             |         |
-|  17    | E06D14.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists#NOT)     |
+|  17    | E06D14.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists.md#NOT)     |
 |  18    | E06D14.2     | date-time                   | 0-1     | dateTime    |         |
 |  19    | E06D14.3     | note-text                   | 1       | string      |         |
 
@@ -301,8 +301,8 @@ E07 CHARGE
 | **1**  |              | **charge<br/>xmlns=<br/>"http://ns.bic.org/lcf/1.0"**                                  |         |             | **Top-level&nbsp;element**<br/>*'version' attribute removed in v1.0.1*                                                         |
 |   2    | E07D01       | identifier                  | 0-1     | string      | Mandatory except when creating a new entity, in which case the identifier will be assigned by the LMS                        |
 | **3**  | **E07D02**   | **patron-ref**              | **1**   | **string**  |         |
-| **4**  | **E07D03**   | **charge-type**             | **1**   | **Code**    | **[CHT](LCF-CodeLists#CHT)** |
-| **5**  | **E07D04**   | **charge-status**           | **1**   | **Code**    | **[CHS](LCF-CodeLists#CHS)** |
+| **4**  | **E07D03**   | **charge-type**             | **1**   | **Code**    | **[CHT](LCF-CodeLists.md#CHT)** |
+| **5**  | **E07D04**   | **charge-status**           | **1**   | **Code**    | **[CHS](LCF-CodeLists.md#CHS)** |
 |   6    | E07D05       | description                 | 0-1     | string      |         |
 |   7    | E07D06       | item-ref                    | 0-1     | string      |         |
 |   8    | E07D07       | manifestation-ref           | 0-1     | string      |         |
@@ -317,7 +317,7 @@ E07 CHARGE
 |  17    | E07D16       | paid-date                   | 0-1     | dateTime    |         |
 |  18    | E07D17       | payment-ref                 | 0-n     | string      |         |
 |  19    | E07C18       | note                        | 0-n     |             |         |
-|  20    | E07D18.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists#NOT)     |
+|  20    | E07D18.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists.md#NOT)     |
 |  21    | E07D18.2     | date-time                   | 0-1     | dateTime    |         |
 |  22    | E07D18.3     | note-text                   | 1       | string      |         |
 
@@ -329,16 +329,16 @@ E08 PAYMENT
 | **1** |              | **payment<br/>xmlns=<br/>"http://ns.bic.org/lcf/1.0"**                                 |         |             | **Top-level&nbsp;element**<br/>*'version' attribute removed in v1.0.1*                                                        |
 |   2   | E08D01       | identifier                  | 0-1     | string      | Mandatory except when creating a new entity, in which case the identifier will be assigned by the LMS                       |
 | **3** | **E08D02**   | **patron-ref**              | **1**   | **string**  |         |
-| **4** | **E08D03**   | **payment-type**            | **1**   | **Code**    | **[PYT](LCF-CodeLists#PYT)** |
+| **4** | **E08D03**   | **payment-type**            | **1**   | **Code**    | **[PYT](LCF-CodeLists.md#PYT)** |
 |   5   | E08D04       | description                 | 0-1     | string      |         |
 |   6   | E08D05       | charge-ref                  | 0-n     | string      | *Non-mandatory in v1.0.1* |
 |   7   | E08D06       | payment-date                | 0-1     | dateTime    |         |
 | **8** | **E08D07**   | **amount**                  | **1**   | **decimal** |         |
 |   9   | E08D08       | currency                    | 0-1     | Code        | ISO currency code                                                                                   |
-|  10   | E08D09       | payment-status              | 0-1     | Code        | [PYS](LCF-CodeLists#PYS)     |
+|  10   | E08D09       | payment-status              | 0-1     | Code        | [PYS](LCF-CodeLists.md#PYS)     |
 |  11   | E08D10       | transaction-reference       | 0-1     | string      | *Renamed in v1.0.1* |
 |  12   | E08C11       | note                        | 0-n     |             |         |
-|  13   | E08D11.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists#NOT)     |
+|  13   | E08D11.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists.md#NOT)     |
 |  14   | E08D11.2     | date-time                   | 0-1     | dateTime    |         |
 |  15   | E08D11.3     | note-text                   | 1       | string      |         |
 
@@ -355,11 +355,11 @@ E09 CONTACT
 |   5   | E09D11       | institution-ref            | 0-1     | string      | Mandatory unless E09D03 or E09D10 present<br/>*Added v1.0.1*                                                             |
 |       | <strike>E09D04</strike> | <strike>address-line</strike> | <strike>0-n</strike> | <strike>string</strike> |                                                                     *Removed v1.0.1* |
 |       | <strike>E09C05</strike> | <strike>communication-detail</strike> | <strike>0-n</strike> |         |                                                                     *Removed v1.0.1* |
-| **6** | **E09D08**   | **communication-type**      | **1**   | **Code**    | **[CMT](LCF-CodeLists#CMT)** |
+| **6** | **E09D08**   | **communication-type**      | **1**   | **Code**    | **[CMT](LCF-CodeLists.md#CMT)** |
 | **7** | **E09D09**   | **locator**                 | **1-n** | **string**  | *Repeatable v1.0.1*                                                                                |
 |       | <strike>E09D06</strike> | <strike>language</strike> | <strike>0-1</strike> | <strike>Code</strike> | <strike>ISO three-letter code</strike><br/>                           *Removed v1.0.1* |
 |   8  | E09C07       | note                         | 0-n     |             |         |
-|   9  | E09D07.1     | note-type                    | 0-1     | Code        | [NOT](LCF-CodeLists#NOT)     |
+|   9  | E09D07.1     | note-type                    | 0-1     | Code        | [NOT](LCF-CodeLists.md#NOT)     |
 |  10  | E09D07.2     | date-time                    | 0-1     | dateTime    |         |
 |  11  | D09D07.3     | note-text                    | 1       | string      |         |
 
@@ -372,7 +372,7 @@ E10 TITLE CLASSIFICATION SCHEME
 |   2   | E10D01       | identifier                  | 0-1     | string      | Mandatory except when creating a new entity, in which case the identifier will be assigned by the LMS                       |
 | **3** | **E10D02**   | **name**                    | **1**   | **string**  |         |
 |   4   | E10C03       | note                        | 0-n     |             |         |
-|   5   | E10D03.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists#NOT)     |
+|   5   | E10D03.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists.md#NOT)     |
 |   6   | E10D03,2     | date-time                   | 0-1     | dateTime    |         |
 |   7   | E10D03.3     | note-text                   | 1       | string      |         |
 
@@ -387,7 +387,7 @@ E11 TITLE CLASSIFICATION TERM
 | **4** | **E11D03**   | **class-scheme-ref**        | **1**   | **string**  |         |
 |   5   | E11D04       | heading                     | 0-1     | string      |         |
 |   6   | E11C05       | note                        | 0-n     | string      |         |
-|   7   | E11D05.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists#NOT)     |
+|   7   | E11D05.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists.md#NOT)     |
 |   8   | E11D05.2     | date-time                   | 0-1     | dateTime    |         |
 |   9   | E11D05.3     | note-text                   | 1       | string      |         |
 
@@ -399,11 +399,11 @@ E12 SELECTION CRITERION *(DEPRECATED in v1.0.1)*
 | **1** |              | **property<br/>xmlns=<br/>"http://ns.bic.org/lcf/1.0"**                                 |         |             | **Top-level&nbsp;element**<br/>*'version' attribute removed in v1.0.1*                                                        |
 |   2   | E12D01       | identifier                  | 0-1     | string      | Mandatory except when creating a new entity, in which case the identifier will be assigned by the LMS                       |
 | <span id="h.gjdgxs" class="anchor"></span>**3** | **E12D02**   | **name**  | **1**   | **string**  |         |
-|   4   | E12D03       | entity-type                 | 0-n     | Code        | [ENT](LCF-CodeLists#ENT)     |
+|   4   | E12D03       | entity-type                 | 0-n     | Code        | [ENT](LCF-CodeLists.md#ENT)     |
 |   5   | E12D04       | description                 | 0-1     | string      |         |
 |   6   | E12D05       | value-scheme-ref            | 0-1     | string      |         |
 |   7   | E12C06       | note                        | 0-n     | string      |         |
-|   8   | E12D06.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists#NOT)     |
+|   8   | E12D06.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists.md#NOT)     |
 |   9   | E12D06.2     | date-time                   | 0-1     | dateTime    |         |
 |  10   | E12D06.3     | note-text                   | 1       | string      |         |
 
@@ -414,10 +414,10 @@ E13 AUTHORISATION CODE *(added in v1.0.1)*
 |-------|--------------|-----------------------------|---------|-------------|---------|
 | **1** |              | **authorisation<br/>xmlns=<br/>"http://ns.bic.org/lcf/1.0"**                                 |       |             | **Top-level&nbsp;element**<br/>                                |
 |   2   | E13D01       | identifier                  | 0-1     | string      | Mandatory except when creating a new entity, in which case the identifier will be assigned by the LMS                       |
-|   3   | E13D02       | authorisation-type          | 0-1     | Code        | [AUT](LCF-CodeLists#AUT) |
+|   3   | E13D02       | authorisation-type          | 0-1     | Code        | [AUT](LCF-CodeLists.md#AUT) |
 |   3   | E13D03       | heading                     | 0-1     | string      |         |
 |   4   | E13C04       | note                        | 0-n     | string      |         |
-|   5   | E13D04.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists#NOT) |
+|   5   | E13D04.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists.md#NOT) |
 |   6   | E13D04.2     | date-time                   | 0-1     | dateTime    |         |
 |   7   | E13D04.3     | note-text                   | 1       | string      |         |
 
@@ -429,22 +429,22 @@ E14 LIBRARY AUTHORITY/INSTITUTION *(added in v1.0.1)*
 | **1** |              | **authority<br/>xmlns=<br/>"http://ns.bic.org/lcf/1.0"**                                     |       |             | **Top-level&nbsp;element**<br/>                                |
 |   2   | E14D01       | identifier                  | 0-1     | string      | Mandatory except when creating a new entity, in which case the identifier will be assigned by the LMS                       |
 |   3   | E14C02       | additional-authority-id     | 0-n     |             |         |
-|   4   | E14D02.1     | authority-id-type           | 1       | Code        | [INS](LCF-CodeLists#INS) |
+|   4   | E14D02.1     | authority-id-type           | 1       | Code        | [INS](LCF-CodeLists.md#INS) |
 |   5   | E14D02.2     | type-name                   | 0-1     | string      |         |
 |   6   | E14D02.3     | value                    | 1       | string      |         |
 | **7** | **E14D03**   | **name**                    | 1       | string      |         |
 |   8   | E14C04       | associated-location         | 0-n     |             |         |
-|   9   | E14D04.1     | association-type            | 1       | Code        | [LAT](LCF-CodeLists#LAT) |
+|   9   | E14D04.1     | association-type            | 1       | Code        | [LAT](LCF-CodeLists.md#LAT) |
 |  10   | E14D04.2     | location-ref                | 1       | string      |         |
 |  11   | E14C05       | associated-contact          | 0-n     |             |         |
-|  12   | E14D05.1     | association-type            | 1       | Code        | [CAT](LCF-CodeLists#CAT) |
+|  12   | E14D05.1     | association-type            | 1       | Code        | [CAT](LCF-CodeLists.md#CAT) |
 |  13   | E14D05.2     | contact-name                | 0-1     | string      |         |
 |  14   | E14D05.3     | contact-ref                 | 1       | string      |         |
 |  15   | E14C06       | associated-authority        | 0-n     |             |         |
-|  16   | E14D06.1     | association-type            | 1       | Code        | [AAT](LCF-CodeLists#AAT) |
+|  16   | E14D06.1     | association-type            | 1       | Code        | [AAT](LCF-CodeLists.md#AAT) |
 |  17   | E14D06.2     | authority-ref               | 1       | string      |         |
 |  20   | E14C07       | note                        | 0-n     |             |         |
-|  21   | E14D07.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists#NOT) |
+|  21   | E14D07.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists.md#NOT) |
 |  22   | E14D07.2     | date-time                   | 0-1     | dateTime    |         |
 |  23   | E14D07.3     | note-text                   | 1       | string      |         |
 
@@ -456,20 +456,20 @@ E15 MESSAGE / ALERT *(added in v1.0.1)*
 | **1** |              | **message-alert<br/>xmlns=<br/>"http://ns.bic.org/lcf/1.0"**                                     |       |             | **Top-level&nbsp;element**<br/>                                |
 |   2   | E15D01       | identifier                  | 0-1     | string      | Mandatory except when creating a new entity, in which case the identifier will be assigned by the LMS                       |
 |   3   | E15D02       | authority-ref               | 0-1     | String      |         |
-| **4** | **E15D03**   | **message-type**            | **1**   | **Code**    | **[MAT](LCF-CodeLists#MAT)** |
-|   5   | E15D04       | priority                    | 0-1     | Code        | [MAP](LCF-CodeLists#MAP) |
-|   6   | E15D05       | display-type                | 0-1     | Code        | [MGT](LCF-CodeLists#MGT) |
-|   7   | E15D06       | display-constraint          | 0-1     | Code        | [MAC](LCF-CodeLists#MAC) |
+| **4** | **E15D03**   | **message-type**            | **1**   | **Code**    | **[MAT](LCF-CodeLists.md#MAT)** |
+|   5   | E15D04       | priority                    | 0-1     | Code        | [MAP](LCF-CodeLists.md#MAP) |
+|   6   | E15D05       | display-type                | 0-1     | Code        | [MGT](LCF-CodeLists.md#MGT) |
+|   7   | E15D06       | display-constraint          | 0-1     | Code        | [MAC](LCF-CodeLists.md#MAC) |
 |   8   | E15D07       | start-date                  | 0-1     | DateTime    |         |
 |   9   | E15D08       | end-date                    | 0-1     | DateTime    |         |
-|  10   | E15D09       | audience                    | 0-1     | Code        | [MAU](LCF-CodeLists#MAU) |
+|  10   | E15D09       | audience                    | 0-1     | Code        | [MAU](LCF-CodeLists.md#MAU) |
 |  11   | E15D10       | patron-category             | 0-n     | String      |         |
 |  12   | E15D11       | patron-ref                  | 0-n     | String      |         |
 |  13   | **E15C12**   | message-text                | **1-n** | String      |         |
-|  14   | **E15D12.1** | message-format              | **1**   | Code        | **[TFT](LCF-CodeLists#TFT)** |
+|  14   | **E15D12.1** | message-format              | **1**   | Code        | **[TFT](LCF-CodeLists.md#TFT)** |
 |  15   | **E15D12.2** | text                        | **1**   | String      |         |
 |  16   | E15C13       | note                        | 0-n     |             |         |
-|  17   | E15D13.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists#NOT) |
+|  17   | E15D13.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists.md#NOT) |
 |  18   | E15D13.2     | date-time                   | 0-1     | dateTime    |         |
 |  19   | E15D13.3     | note-text                   | 1       | string      |         |
 
@@ -480,11 +480,11 @@ EXCEPTION CONDITIONS
 |-------|--------------|-----------------------------|---------|-------------|---------|
 | **1** |              | **lcf-exception<br/>xmlns=<br/>"http://ns.bic.org/lcf/1.0"**                                 |         |             | **Top-level&nbsp;element**<br/>*'version' attribute removed in v1.0.1*                                                        |
 | **2** | **R00C05**   | **exception-condition**     | **1-n** |             |         |
-| **3** | **R00D05.1** | **condition-type**          | **1**   | **Code**    | **[EXC](LCF-CodeLists#EXC)** |
-|   4   | R00D05.2     | reason-denied               | 0-1     | Code        | [RDN](LCF-CodeLists#RDN)     |
+| **3** | **R00D05.1** | **condition-type**          | **1**   | **Code**    | **[EXC](LCF-CodeLists.md#EXC)** |
+|   4   | R00D05.2     | reason-denied               | 0-1     | Code        | [RDN](LCF-CodeLists.md#RDN)     |
 |   5   | R00D05.3     | element-ref                 | 0-1     | string      |         |
 |   6   | R00C06       | message                     | 0-n     |             |         |
-|   7   | R00D06.1     | message-type                | 1       | string      | [MGT](LCF-CodeLists#MGT)     |
+|   7   | R00D06.1     | message-type                | 1       | string      | [MGT](LCF-CodeLists.md#MGT)     |
 |   8   | R00D06.2     | message-text                | 1-n     | string      |         |
 
 

--- a/docs/LCF-RESTWebServiceSpecification.md
+++ b/docs/LCF-RESTWebServiceSpecification.md
@@ -132,7 +132,7 @@ The request is formulated using the HTTP GET method.
 |-------|--------------|-----------------------|-----------------------|---------|-------------|--------------|
 | **1** |              | **/lcf**              |                       | **1**   |             | LCF initial segment                                                                                                       |
 | **2** |              | **/1.0**              |                       | **1**   |             | LCF version number                                                                                                        |
-| **3** | **Q01D01**   | **/{entity-type}**    |                       | **1**   | **Code**    | **The alpha code value is used from code list [ENT](LCF-CodeLists#ENT)**                                                                            |
+| **3** | **Q01D01**   | **/{entity-type}**    |                       | **1**   | **Code**    | **The alpha code value is used from code list [ENT](LCF-CodeLists.md#ENT)**                                                                            |
 | **4** | **Q01D02**   | **/{id-value}**       |                       | **1**   | **string**  |              |
 
 NOTE – LCF element Q01D03 is not implemented in this binding.
@@ -158,10 +158,10 @@ The request is formulated using the HTTP GET method.
 |-------|--------------|-----------------------|-----------------------|---------|-------------|--------------|
 | **1** |              | **/lcf**              |                       | **1**   |             | LCF&nbsp;initial&nbsp;segment                                                                                                       |
 | **2** |              | **/1.0**              |                       | **1**   |             | LCF version number |
-| 3     |              | /{key-entity-type}    |                       | 0-1     | Code        | Key entity type, when retrieving a list of entities relating to a specific key entity, e.g. a list of items relating to a specific manifestation, or a list of charges relating to a specific patron. If included in the request, the identifier of the key entity must also be included. The alpha code value is used from code list [ENT](LCF-CodeLists#ENT)         |
+| 3     |              | /{key-entity-type}    |                       | 0-1     | Code        | Key entity type, when retrieving a list of entities relating to a specific key entity, e.g. a list of items relating to a specific manifestation, or a list of charges relating to a specific patron. If included in the request, the identifier of the key entity must also be included. The alpha code value is used from code list [ENT](LCF-CodeLists.md#ENT)         |
 | 4     |              | /{key-entity-id-value}|                       | 0-1     | string      |              |
-| **5** | **Q02D01**   | **/{entity-type}**    |                       | **1**   | **Code**    | **The alpha code value is used from code list [ENT](LCF-CodeLists#ENT)**                                                             |
-| 6     | Q02C02       |                       | {selection-criterion-code}| 0-n | Variable    | Each query parameter name must be the alpha version of a selection criterion code as specified in code list [SEL](LCF-CodeLists#SEL). The parameter name and value in each case correspond to Q02D02.1 and Q02D02.2 respectively in the LCF v1.0.1 specification. |
+| **5** | **Q02D01**   | **/{entity-type}**    |                       | **1**   | **Code**    | **The alpha code value is used from code list [ENT](LCF-CodeLists.md#ENT)**                                                             |
+| 6     | Q02C02       |                       | {selection-criterion-code}| 0-n | Variable    | Each query parameter name must be the alpha version of a selection criterion code as specified in code list [SEL](LCF-CodeLists.md#SEL). The parameter name and value in each case correspond to Q02D02.1 and Q02D02.2 respectively in the LCF v1.0.1 specification. |
 | 7     | Q02D04       |                       | os:count              | 0-1     | int         | Implements the OpenSearch 1.1 'count' parameter                                                                                         |
 | 8     | Q02D05       |                       | os:startIndex         | 0-1     | int         | Implements the OpenSearch 1.1 'startIndex' parameter                                                                                    |
 
@@ -184,9 +184,9 @@ If the server is able to process the request, but no entities match the criteria
 |       | *Element ID* | *XML structure*                         | *Card.* | *Data type* | *Notes*            |
 |-------|--------------|-----------------------------------------|---------|-------------|--------------------|
 | **1** |              | **lcf-entity-list-response<br>xmlns="http://ns.bic.org/lcf/1.0"<br>xmlns:os=<br>"http://a9.com/-/spec/opensearch/1.1/"**              | **1**   |             | **Top-level message element with namespace declarations**<br/>*'version' attribute removed in v1.0.1*                                          |
-| **2** | **R02D01**   | **entity-type**                         | **1**   | **Code**    | **The alpha code value is used from code list [ENT](LCF-CodeLists#ENT)**                                                                                          |
+| **2** | **R02D01**   | **entity-type**                         | **1**   | **Code**    | **The alpha code value is used from code list [ENT](LCF-CodeLists.md#ENT)**                                                                                          |
 | 3     | R02C02       | selection-criterion                     | 0-n     |             | If the request contains a key entity reference, a selection-criterion should contain the entity type and identifier of the key entity.      |
-| 4     | R02D02.1     | code                                    | 1       | Code        | The alpha code value is used from code list [SEL](LCF-CodeLists#SEL)                                                                    |
+| 4     | R02D02.1     | code                                    | 1       | Code        | The alpha code value is used from code list [SEL](LCF-CodeLists.md#SEL)                                                                    |
 | 5     | R02D02.2     | value                                   | 1       | string      |                    |
 | 6     | R02D03       | os:totalResults                         | 0-1     | int         |                    |
 | 7     | R02D04       | os:itemsPerPage                         | 0-1     | int         |                    |
@@ -215,9 +215,9 @@ The request is formulated using the HTTP POST method. The payload is an XML docu
 |-------|--------------|-----------------------|-----------------------|---------|-------------|--------------|
 | **1** |              | **/lcf**              |                       | **1**   |             | LCF initial segment |
 | **2** |              | **/1.0**              |                       | **1**   |             | LCF version number  |
-| 3     |              | /{key-entity-type}    |                       | 0-1     | Code        | Key entity type, when creating an entity relating to a specific key entity, e.g. an item that is a copy of a specific manifestation. If included in the request, the identifier of the key entity must also be included. The alpha code value is used from code list [ENT](LCF-CodeLists#ENT) |
+| 3     |              | /{key-entity-type}    |                       | 0-1     | Code        | Key entity type, when creating an entity relating to a specific key entity, e.g. an item that is a copy of a specific manifestation. If included in the request, the identifier of the key entity must also be included. The alpha code value is used from code list [ENT](LCF-CodeLists.md#ENT) |
 | 4     |              | /{key-id-value}       |                       | 0-1     | string      |              |
-| **5** | **Q03D01**   | **/{entity-type}**    |                       | **1**   | **Code**    | **The alpha code value is used from code list [ENT](LCF-CodeLists#ENT)**                                                    |
+| **5** | **Q03D01**   | **/{entity-type}**    |                       | **1**   | **Code**    | **The alpha code value is used from code list [ENT](LCF-CodeLists.md#ENT)**                                                    |
 
 *Examples of a Request*
 
@@ -242,7 +242,7 @@ The request is formulated using the HTTP PUT method. The payload is an XML docum
 |-------|--------------|-----------------------|-----------------------|---------|-------------|--------------|
 | **1** |              | **/lcf**              |                       | **1**   |             | LCF initial segment |
 | **2** |              | **/1.0**              |                       | **1**   |             | LCF version number  |
-| **3** | **Q04D01**   | **/{entity-type}**    |                       | **1**   | **Code**    | **The alpha code value is used from code list [ENT](LCF-CodeLists#ENT)**                                                                                     |
+| **3** | **Q04D01**   | **/{entity-type}**    |                       | **1**   | **Code**    | **The alpha code value is used from code list [ENT](LCF-CodeLists.md#ENT)**                                                                                     |
 | **4** | **Q04D02**   | **/{item-ref}**       |                       | **1**   |             |              |
 
 NOTE – This function replaces the entity item identified in the request with the content of the payload. LCF element Q04D03 is therefore implicitly included with value '01'.
@@ -266,7 +266,7 @@ The request is formulated using the HTTP DELETE method.
 |-------|--------------|-----------------------|-----------------------|---------|-------------|--------------|
 | **1** |              | **/lcf**              |                       | **1**   |             | LCF initial segment |
 | **2** |              | **/1.0**              |                       | **1**   |             | LCF version number  |
-| **3** | **Q05D01**   | **/{entity-type}**    |                       | **1**   | **Code**    | **The alpha code value is used from code list [ENT](LCF-CodeLists#ENT)**                                                                                     |
+| **3** | **Q05D01**   | **/{entity-type}**    |                       | **1**   | **Code**    | **The alpha code value is used from code list [ENT](LCF-CodeLists.md#ENT)**                                                                                     |
 | **4** | **Q05D02**   | **/{item-id}**        |                       | **1**   |             |              |
 
 *Example of a Request*
@@ -326,8 +326,8 @@ The response to a check-out or renewal may be the same response as for creating 
 | **1** |              | **lcf-check-out-response** | **1**   |             | **Top-level message element**<br/>*'version' attribute removed in v1.0.1*                                                                  |
 | 2     | R11D01       | loan-ref                                 | 0-1     | anyURI      | One of R11D01, R11C02 or R11D03 must be included in the response.                                                                      |
 | 3     | R11C02       | loan                                     | 0-1     |             | See E05           |
-| 4     | R11D03       | media-warning                            | 0-1     | Code        | [MEW](LCF-CodeLists#MEW) – Omitted if responding to a renewal                                                              |
-| 5     | R11D04       | security-desensitize                     | 0-1     | Code        | [SCD](LCF-CodeLists#SCD) – Omitted if responding to a renewal                                                              |
+| 4     | R11D03       | media-warning                            | 0-1     | Code        | [MEW](LCF-CodeLists.md#MEW) – Omitted if responding to a renewal                                                              |
+| 5     | R11D04       | security-desensitize                     | 0-1     | Code        | [SCD](LCF-CodeLists.md#SCD) – Omitted if responding to a renewal                                                              |
 | 6     | R11D05       | charge-ref                               | 0-1     | anyURI      |                   |
 | 7     | R11D06       | access-link                              | 0-1     | anyURI      | *Added v1.0.1*    |
 
@@ -380,8 +380,8 @@ A check-in response may be the same response as for modifying any entity, or may
 | **1** |              | **lcf-check-in-response** | **1**   |             | **Top-level message element**<br/>*'version' attribute removed in v1.0.1*                                                                               |
 | **2** | **R12D01**   | **loan-ref**                            | **1**   | **anyURI**  |                    |
 | 3     | R12D04       | return-location-ref                     | 0-1     | anyURI      |                    |
-| 4     | R12D05       | media-warning                           | 0-1     | Code        | [MEW](LCF-CodeLists#MEW)                |
-| 5     | R12D06       | special-attention                       | 0-1     | Code        | [SPA](LCF-CodeLists#SPA)                |
+| 4     | R12D05       | media-warning                           | 0-1     | Code        | [MEW](LCF-CodeLists.md#MEW)                |
+| 5     | R12D06       | special-attention                       | 0-1     | Code        | [SPA](LCF-CodeLists.md#SPA)                |
 | 6     | R12D07       | special-attention-note                  | 0-1     | string      |                    |
 | 7     | R12D08       | charge-ref                              | 0-n     | anyURI      |                    |
 


### PR DESCRIPTION
Code list links fixed by adding '.md' to all file names.