### PR TITLE
Change name of element-ref in exception-condition

### DIFF
--- a/docs/LCF-InformationEntityXMLBindings.md
+++ b/docs/LCF-InformationEntityXMLBindings.md
@@ -482,7 +482,7 @@ EXCEPTION CONDITIONS
 | **2** | **R00C05**   | **exception-condition**     | **1-n** |             |         |
 | **3** | **R00D05.1** | **condition-type**          | **1**   | **Code**    | **[EXC](LCF-CodeLists#EXC)** |
 |   4   | R00D05.2     | reason-denied               | 0-1     | Code        | [RDN](LCF-CodeLists#RDN)     |
-|   5   | R00D05.3     | element-ref                 | 0-1     | string      |         |
+|   5   | R00D05.3     | element-id                  | 0-1     | string      |         |
 |   6   | R00C06       | message                     | 0-n     |             |         |
 |   7   | R00D06.1     | message-type                | 1       | string      | [MGT](LCF-CodeLists#MGT)     |
 |   8   | R00D06.2     | message-text                | 1-n     | string      |         |

--- a/lcf-schema/src/main/resources/lcf-v1.0-rest-responses.xsd
+++ b/lcf-schema/src/main/resources/lcf-v1.0-rest-responses.xsd
@@ -69,7 +69,7 @@
 
     <xs:element name="code" type="selectionCriteria"/>
     <xs:element name="condition-type" type="exceptionConditionType"/>
-    <xs:element name="element-ref" type="lcfEntityReference"/>
+    <xs:element name="element-id" type="nonEmptyString"/>
     <xs:element name="entity">
         <xs:complexType>
             <xs:attribute name="href" type="xs:anyURI"/>

--- a/lcf-schema/src/main/resources/lcf-v1.0-rest-responses.xsd
+++ b/lcf-schema/src/main/resources/lcf-v1.0-rest-responses.xsd
@@ -69,7 +69,7 @@
 
     <xs:element name="code" type="selectionCriteria"/>
     <xs:element name="condition-type" type="exceptionConditionType"/>
-    <xs:element name="element-ref" type="nonEmptyString"/>
+    <xs:element name="element-ref" type="lcfEntityReference"/>
     <xs:element name="entity">
         <xs:complexType>
             <xs:attribute name="href" type="xs:anyURI"/>


### PR DESCRIPTION
Update type of element-ref of exception-condition in the lcf-exception REST response to lcfEntityReference rather than nonEmptyString as per issue #162