### PR TITLE
Add loan and reservation reference elements to the Message/Alert

### DIFF
--- a/docs/LCF-CodeLists.md
+++ b/docs/LCF-CodeLists.md
@@ -396,6 +396,8 @@ NOTE – This code list is to be revised in consultation with libraries. The exi
   --------- |-------------- |----------------------------------- |------------------------------
   MAU01     |01             |All patrons                         |
   MAU02     |02             |Specified patrons and categories    |
+  MAU03     |03             |Patrons related to specified loans  | *Added in LCF v1.1.0*
+  MAU04     |04             |Patrons related to specified reservations | *Added in LCF v1.1.0*
 
 ### <a id="MES"></a>MES Media type / format scheme
 

--- a/docs/LCF-DataFrameworks.md
+++ b/docs/LCF-DataFrameworks.md
@@ -670,8 +670,10 @@ A message or alert that may be communicated to a patron or group of patrons.
 | E15D07     | Display from date-time     |            | 0-1     | DateTime   |                                |
 | E15D08     | Display until date-time    |            | 0-1     | DateTime   |                                |
 | E15D09     | Message/alert audience     |            | 0-1     | Code       | LCF code list **[MAU](LCF-CodeLists.md#MAU)**                                                                                                  |
-| E15D10     | Patron category            |            | 0-n     | String     | Only included if audience is not all patrons |
-| E15D11     | Patron reference           |            | 0-n     | String     | Only included if audience is not all patrons |
+| E15D10     | Patron category            |            | 0-n     | String     | Only included if audience is specified patrons and categories |
+| E15D11     | Patron reference           |            | 0-n     | String     | Only included if audience is specified patrons and categories |
+| E15D14     | Loan reference             |            | 0-n     | String     | Only included if audience is patrons related to specified loans |
+| E15D15     | Reservation reference      |            | 0-n     | String     | Only included if audience is patrons related to specified reservations |
 | ***E15C12***  | **Message/alert text**  |            | **1-n** |            | Repeatable if the message/alert text is available in several alternative text formats                                                               |
 | **E15D12.1**  | Text format             |            | **1**   | Code       | LCF code list **[TFT](LCF-CodeLists.md#TFT)**                                                                                                  |
 | **E15D12.2**  | Text string             |            | **1**   | String     |                                |

--- a/docs/LCF-InformationEntityXMLBindings.md
+++ b/docs/LCF-InformationEntityXMLBindings.md
@@ -468,13 +468,14 @@ E15 MESSAGE / ALERT *(added in v1.0.1)*
 |  10   | E15D09       | audience                    | 0-1     | Code        | [MAU](LCF-CodeLists#MAU) |
 |  11   | E15D10       | patron-category             | 0-n     | String      |         |
 |  12   | E15D11       | patron-ref                  | 0-n     | String      |         |
-|  13   | **E15C12**   | message-text                | **1-n** | String      |         |
-|  14   | **E15D12.1** | message-format              | **1**   | Code        | **[TFT](LCF-CodeLists#TFT)** |
-|  15   | **E15D12.2** | text                        | **1**   | String      |         |
-|  16   | E15C13       | note                        | 0-n     |             |         |
-|  17   | E15D13.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists#NOT) |
-|  18   | E15D13.2     | date-time                   | 0-1     | dateTime    |         |
-|  19   | E15D13.3     | note-text                   | 1       | string      |         |
+|  13   | E15D14       | loan-ref                    | 0-n     | String      | *Added in v1.1.0* |
+|  14   | E15D15       | reservation-ref             | 0-n     | String      | *Added in v1.1.0* |
+|  15   | **E15D12.1** | message-format              | **1**   | Code        | **[TFT](LCF-CodeLists#TFT)** |
+|  16   | **E15D12.2** | text                        | **1**   | String      |         |
+|  17   | E15C13       | note                        | 0-n     |             |         |
+|  18   | E15D13.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists#NOT) |
+|  19   | E15D13.2     | date-time                   | 0-1     | dateTime    |         |
+|  20   | E15D13.3     | note-text                   | 1       | string      |         |
 
 EXCEPTION CONDITIONS
 --------------------

--- a/lcf-schema/src/main/resources/lcf-v1.0-codelists.xsd
+++ b/lcf-schema/src/main/resources/lcf-v1.0-codelists.xsd
@@ -956,6 +956,20 @@
                     <xs:documentation source="https://bic-org-uk.github.io/bic-lcf/LCF-CodeLists#Notes"></xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
+            <xs:enumeration value="03">
+                <xs:annotation>
+                    <xs:appinfo source="https://bic-org-uk.github.io/bic-lcf/LCF-CodeLists#CodeID">MAU03</xs:appinfo>
+                    <xs:documentation source="https://bic-org-uk.github.io/bic-lcf/LCF-CodeLists#Definition">Patrons related to specified loans. Added in LCF v1.1.0</xs:documentation>
+                    <xs:documentation source="https://bic-org-uk.github.io/bic-lcf/LCF-CodeLists#Notes"></xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="04">
+                <xs:annotation>
+                    <xs:appinfo source="https://bic-org-uk.github.io/bic-lcf/LCF-CodeLists#CodeID">MAU04</xs:appinfo>
+                    <xs:documentation source="https://bic-org-uk.github.io/bic-lcf/LCF-CodeLists#Definition">Patrons related to specified reservations. Added in LCF v1.1.0</xs:documentation>
+                    <xs:documentation source="https://bic-org-uk.github.io/bic-lcf/LCF-CodeLists#Notes"></xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="messageAlertPriority">

--- a/lcf-schema/src/main/resources/lcf-v1.0-entities.xsd
+++ b/lcf-schema/src/main/resources/lcf-v1.0-entities.xsd
@@ -333,6 +333,8 @@
             <xs:element ref="audience" minOccurs="0"/>
             <xs:element ref="patron-category" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element ref="patron-ref" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="loan-ref" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="reservation-ref" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element ref="message-text" maxOccurs="unbounded"/>
             <xs:element ref="note" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>


### PR DESCRIPTION
Add loan and reservation reference elements to the Message/Alert entity and corresponding entries to the Message/Alert Audience code list

See issue #140