### PR TITLE
Add LCF version to all responses

### DIFF
--- a/docs/LCF-DataFrameworks.md
+++ b/docs/LCF-DataFrameworks.md
@@ -721,6 +721,7 @@ The following data elements and composites are typically used for control of mes
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
 | R00D01     | Response ID                |            | 0-1     | String    | An ID of a response.            |
 | R00D02     | Response type              |            | 0-1     | Code      | LCF code list **[RST](LCF-CodeLists.md#RST)**               |
+| R00D07     | LCF version                |            | 0-1     | String    | Number of LCF version supported by the responding application. The string should use the same Semantic Versioning number format as LCF as a whole.<br/>*Added in v1.2.0* |
 | R00D03     | Request reference          |            | 0-1     | String    | The ID of the request to which this is the response. Mandatory if the request included a request ID.                                               |
 | R00D04     | Response date-time         |            | 0-1     | DateTime  | The date and time of the response.|
 | *R00C05*   | *Exception condition*      |            | 0-n     |           | Response if there is an exception condition, in which case this and, optionally, one or more of the following message elements terminate the response.|

--- a/docs/LCF-RESTWebServiceSpecification.md
+++ b/docs/LCF-RESTWebServiceSpecification.md
@@ -116,6 +116,12 @@ In a RESTful web service implementation exception condition responses should gen
 
 The URI syntax rules don't allow certain characters in query parts, including the space character. Although these rules allow a space character to be represented by a '+' sign, it is recommended that all non-allowed characters should always be encoded using percent encoding, i.e. '%' followed by hexadecimal digits representing the character's Unicode character number.
 
+#### 7. Reporting LCF version in responses *(Added in v1.2.0)*
+
+The LCF element R00D07 should be carried by a custom field 'lcf-version' in the HTTP(S) response header, e.g.
+
+    lcf-version: 1.2.0
+
 #### 
 
 Core functions


### PR DESCRIPTION
Add optional LCF version to all responses, including error/exception responses. See issue #201.