### PR TITLE
Changes to cardinalities of response elements

### DIFF
--- a/docs/LCF-DataFrameworks.md
+++ b/docs/LCF-DataFrameworks.md
@@ -813,8 +813,8 @@ This function is used to create a new item of a specific entity type. In practic
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **R03D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists.md#ENT)<br/>The entity type of the item created in response to the request.**                                                         |
-| **R03D02** | **Item identifier**        |            | **1**   | **String**| **The LCF entity identifier for the inventory item, assigned by the LMS if a new item has been successfully created.**                             |
+| R03D01     | Entity type                |            | 0-1     | Code      | LCF code list [ENT](LCF-CodeLists.md#ENT)<br/>The entity type of the item created in response to the request.<br/>*Cardinality changed in v1.2.0*                       |
+| R03D02     | Item identifier            |            | 0-1     | String    | The LCF entity identifier for the inventory item, assigned by the LMS if a new item has been successfully created.<br/>*Cardinality changed in v1.2.0*           |
 
 ***
 
@@ -836,8 +836,8 @@ This function is used to modify an existing item of a specific entity type.
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **R04D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists.md#ENT)<br/>The entity type of the item created in response to the request.**                                                         |
-| **R04D02** | **Item identifier**        |            | **1**   | **String**| **The identifier for the item that has been successfully modified.**                                                                              |
+| R04D01     | Entity type                |            | 0-1     | Code      | LCF code list [ENT](LCF-CodeLists.md#ENT)<br/>The entity type of the item created in response to the request.<br/>*Cardinality changed in v1.2.0*                       |
+| R04D02     | Item identifier            |            | 0-1     | String    | The identifier for the item that has been successfully modified.<br/>*Cardinality changed in v1.2.0*                                                                  |
 
 ***
 
@@ -857,8 +857,8 @@ This function is used to delete an item of a specific entity type. Since deletio
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **R05D01** | **Entity type**            |            | **1**   | **Code**  | **LCF code list [ENT](LCF-CodeLists.md#ENT)<br/>The entity type of the item created in response to the request.**                                                         |
-| **R05D02** | **Item identifier**        |            | **1**   | **String**| **The identifier of the item that has been successfully deleted**                                                                                    |
+| R05D01     | Entity type                |            | 0-1     | Code      | LCF code list [ENT](LCF-CodeLists.md#ENT)<br/>The entity type of the item created in response to the request.<br/>*Cardinality changed in v1.2.0*                       |
+| R05D02     | Item identifier            |            | 0-1     | String    | The identifier of the item that has been successfully deleted<br/>*Cardinality changed in v1.2.0*                                                                    |
 
 Circulation management functions
 --------------------------------
@@ -969,7 +969,7 @@ The patron payment function, if successfully executed, causes an LMS to perform 
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **R13D01** | **Patron reference**       | **AA**     | **1**   | **String**|                                 |
+| R13D01     | Patron reference           | AA         | 0-1     | String    | *Cardinality changed in v1.2.0* |
 | R13D02     | Payment Identifier         |            | 0-1     | String    | Included if attempt to make the payment is successful.                                                                                                 |
 | R13D03     | Charge reference           |            | 0-n     |           | Mandatory if payment of any charge item is accepted or confirmed.                                                                                      |
 | R13D04     | Authorisation reference    |            | 0-1     | String    | Reference to an authorisation entity when the LMS needs to authorise that a payment transaction can proceed. The authorisation must be of type AUT02.<br/>*Added in v1.0.1*                     |
@@ -991,7 +991,7 @@ Used to prevent unauthorised use of a patron account, such as when the patron’
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **R14D01** | **Patron reference**       |            | **1**   | **String**| **The identifier for the Patron record that has been successfully modified.**                                                                  |
+| R14D01     | Patron reference           |            | 0-1     | String    | The identifier for the Patron record that has been successfully modified.<br/>*Cardinality changed in v1.2.0*                                                     |
 
 ***
 
@@ -1010,7 +1010,7 @@ This function is very similar to function 14 Block patron. A patron record is re
 
 | *Id*       | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
-| **R15D01** | **Patron reference**       |            | **1**   | **String**| **The identifier for the Patron record that has been successfully modified.**                                                                  |
+| R15D01     | Patron reference           |            | 0-1     | String    | The identifier for the Patron record that has been successfully modified.<br/>*Cardinality changed in v1.2.0*                                                     |
 
 ***
 

--- a/docs/LCF-DataFrameworks.md
+++ b/docs/LCF-DataFrameworks.md
@@ -935,6 +935,7 @@ The check-in function, if successfully executed, causes an LMS to perform a numb
 | Id         | *Element*                  | *SIP2 ID*  | *Card.* | *Format*  | *Description*                   |
 |------------|----------------------------|------------|---------|-----------|---------------------------------|
 | R12D01     | Loan reference             |            | 0-1     | String    |                                 |
+| R12C09     | Loan entity record         |            | 0-1     |           | See E05 *Added in v1.2.0*       |
 | R12D02     | Patron reference           | AA         | 0-1     | String    |                                 |
 | R12D03     | Item reference             | AB         | 0-1     | String    |                                 |
 | R12D04     | Item return location reference| CL      | 0-1     | String    | LCF entity identifier for return location, e.g. sort bin.                                                                                       |

--- a/docs/LCF-RESTWebServiceSpecification.md
+++ b/docs/LCF-RESTWebServiceSpecification.md
@@ -330,8 +330,8 @@ The response to a check-out or renewal may be the same response as for creating 
 |       | *Element ID* | *XML structure*                          | *Card.* | *Data type* | *Notes*           |
 |-------|--------------|------------------------------------------|---------|-------------|-------------------|
 | **1** |              | **lcf-check-out-response** | **1**   |             | **Top-level message element**<br/>*'version' attribute removed in v1.0.1*                                                                  |
-| 2     | R11D01       | loan-ref                                 | 0-1     | anyURI      | One of R11D01, R11C02 or R11D03 must be included in the response.                                                                      |
-| 3     | R11C02       | loan                                     | 0-1     |             | See E05           |
+| ~~2~~ | ~~R11D01~~   | ~~loan-ref~~                             | ~~0-1~~ | ~~anyURI~~  | ~~One of R11D01, R11C02 or R11D03 must be included in the response.~~ (Removed in 1.2.0)                                              |
+| **3** | **R11C02**   | **loan**                                 | **1** |             | **See E05 (Cardinality changed in 1.2.0)** |
 | 4     | R11D03       | media-warning                            | 0-1     | Code        | [MEW](LCF-CodeLists.md#MEW) – Omitted if responding to a renewal                                                              |
 | 5     | R11D04       | security-desensitize                     | 0-1     | Code        | [SCD](LCF-CodeLists.md#SCD) – Omitted if responding to a renewal                                                              |
 | 6     | R11D05       | charge-ref                               | 0-1     | anyURI      |                   |
@@ -381,15 +381,15 @@ This presumes that a number of consequential functions are performed server-side
 
 A check-in response may be the same response as for modifying any entity, or may contain an XML message that conforms to the following schema. The advantage of including the XML payload in the response is that the terminal application will thereby be alerted by the inclusion of any of R12D04 – R12D08 in the response.
 
-|       | *Element ID* | *XML structure*                         | *Card.* | *Data type* | *Notes*            |
-|-------|--------------|-----------------------------------------|---------|-------------|--------------------|
-| **1** |              | **lcf-check-in-response** | **1**   |             | **Top-level message element**<br/>*'version' attribute removed in v1.0.1*                                                                               |
-| **2** | **R12D01**   | **loan-ref**                            | **1**   | **anyURI**  |                    |
-| 3     | R12D04       | return-location-ref                     | 0-1     | anyURI      |                    |
-| 4     | R12D05       | media-warning                           | 0-1     | Code        | [MEW](LCF-CodeLists.md#MEW)                |
-| 5     | R12D06       | special-attention                       | 0-1     | Code        | [SPA](LCF-CodeLists.md#SPA)                |
-| 6     | R12D07       | special-attention-note                  | 0-1     | string      |                    |
-| 7     | R12D08       | charge-ref                              | 0-n     | anyURI      |                    |
+|       | *Element ID* | *XML structure*           | *Card.* | *Data type* | *Notes*                                                      |
+| ----- | ------------ | ------------------------- | ------- | ----------- | ------------------------------------------------------------ |
+| **1** |              | **lcf-check-in-response** | **1**   |             | **Top-level message element**<br/>*'version' attribute removed in v1.0.1* |
+| **2** | **R12D01**   | **loan**                  | **1**   |             | See E05 (Type changed in 1.2.0)                              |
+| 3     | R12D04       | return-location-ref       | 0-1     | anyURI      |                                                              |
+| 4     | R12D05       | media-warning             | 0-1     | Code        | [MEW](LCF-CodeLists.md#MEW)                                  |
+| 5     | R12D06       | special-attention         | 0-1     | Code        | [SPA](LCF-CodeLists.md#SPA)                                  |
+| 6     | R12D07       | special-attention-note    | 0-1     | string      |                                                              |
+| 7     | R12D08       | charge-ref                | 0-n     | anyURI      |                                                              |
 
 *Example of a Response XML payload:*
 

--- a/docs/LCF-RESTWebServiceSpecification.md
+++ b/docs/LCF-RESTWebServiceSpecification.md
@@ -331,7 +331,7 @@ The response to a check-out or renewal may be the same response as for creating 
 |-------|--------------|------------------------------------------|---------|-------------|-------------------|
 | **1** |              | **lcf-check-out-response** | **1**   |             | **Top-level message element**<br/>*'version' attribute removed in v1.0.1*                                                                  |
 | ~~2~~ | ~~R11D01~~   | ~~loan-ref~~                             | ~~0-1~~ | ~~anyURI~~  | ~~One of R11D01, R11C02 or R11D03 must be included in the response.~~ (Removed in 1.2.0)                                              |
-| **3** | **R11C02**   | **loan**                                 | **1** |             | **See E05 (Cardinality changed in 1.2.0)** |
+| **3** | **R12C09**   | **loan**                                 | **1** |             | **See E05 (Cardinality changed in 1.2.0)** |
 | 4     | R11D03       | media-warning                            | 0-1     | Code        | [MEW](LCF-CodeLists.md#MEW) – Omitted if responding to a renewal                                                              |
 | 5     | R11D04       | security-desensitize                     | 0-1     | Code        | [SCD](LCF-CodeLists.md#SCD) – Omitted if responding to a renewal                                                              |
 | 6     | R11D05       | charge-ref                               | 0-1     | anyURI      |                   |

--- a/lcf-schema/src/main/resources/lcf-v1.0-rest-responses.xsd
+++ b/lcf-schema/src/main/resources/lcf-v1.0-rest-responses.xsd
@@ -34,10 +34,7 @@
     <xs:element name="lcf-check-out-response">
         <xs:complexType>
             <xs:sequence>
-                <xs:choice>
-                    <xs:element ref="loan-ref"/>
-                    <xs:element ref="loan"/>
-                </xs:choice>
+                <xs:element ref="loan"/>
                 <xs:element ref="media-warning" minOccurs="0"/>
                 <xs:element ref="security-desensitize" minOccurs="0"/>
             </xs:sequence>
@@ -46,7 +43,7 @@
     <xs:element name="lcf-check-in-response">
         <xs:complexType>
             <xs:sequence>
-                <xs:element ref="loan-ref" minOccurs="0"/>
+                <xs:element ref="loan"/>
                 <xs:element ref="return-location-ref" minOccurs="0"/>
                 <xs:element ref="media-warning" minOccurs="0"/>
                 <xs:element ref="special-attention" minOccurs="0"/>


### PR DESCRIPTION
See issue #226. Cardinalities of elements not implemented in REST have been changed from '1' (mandatory) to '0-1' (non-mandatory). This affects the responses in functions 3, 4, 5, 13, 14, 15.