### PR TITLE
Updates to associated-location

### DIFF
--- a/lcf-schema/src/main/resources/lcf-v1.0-elements.xsd
+++ b/lcf-schema/src/main/resources/lcf-v1.0-elements.xsd
@@ -94,7 +94,7 @@
             <xs:sequence>
                 <xs:element name="association-type" type="locationAssociationType"/>
                 <xs:element ref="location-ref"/>
-                <xs:element ref="library-opening-closing"/>
+                <xs:element ref="library-location-service-period"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -160,7 +160,13 @@
             </xs:sequence>
         </xs:complexType>
     </xs:element>
-    <xs:element name="closing-time" type="xs:time"/>
+    <xs:element name="closed">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="days" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
     <xs:element name="communication-type" type="communicationType">
         <xs:annotation>
             <xs:documentation source="https://bic-org-uk.github.io/bic-lcf/LCF-DataFrameworks#Notes">Value from the CMT list, which determines how the locator multiplicity should work. </xs:documentation>
@@ -235,6 +241,7 @@
     <xs:element name="edition-statement" type="nonEmptyString"/>
     <xs:element name="end-date" type="xs:dateTime"/>
     <xs:element name="end-due-date" type="xs:dateTime"/>
+    <xs:element name="end-time" type="xs:time"/>
     <xs:element name="fee-description" type="nonEmptyString"/>
     <xs:element name="fee-due-date-time" type="xs:dateTime"/>
     <xs:element name="fee-type" type="chargeType"/>
@@ -256,14 +263,14 @@
     <xs:element name="items-in-stock" type="xs:int"/>
     <xs:element name="language" type="iso639LanguageCode"/>
     <xs:element name="lead-patron-ref" type="lcfEntityReference"/>
-    <xs:element name="library-opening-closing">
+    <xs:element name="library-location-service-period">
         <xs:complexType>
             <xs:sequence>
-                <xs:element ref="days" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="season" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="opening-time"/>                
-                <xs:element ref="closing-time"/>  
-                <xs:element ref="staffed" minOccurs="0"/>              
+                <xs:element ref="period" minOccurs="0"/>
+                <xs:element ref="start-date"/>
+                <xs:element ref="end-date"/>
+                <xs:element ref="closed" minOccurs="0"/>
+                <xs:element ref="open" minOccurs="0" maxOccurs="unbounded"/>                
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -339,7 +346,23 @@
     <xs:element name="note-type" type="noteType"/>
     <xs:element name="on-loan-items" type="xs:int"/>
     <xs:element name="on-loan-ref" type="lcfEntityReference"/>
-    <xs:element name="opening-time" type="xs:time"/>
+    <xs:element name="open">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="days" minOccurs="0"/>
+                <xs:element ref="open-time-period"> maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="open-time-period">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="start-time"/>
+                <xs:element ref="end-time"/>
+                <xs:element ref="staffed" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    <xs:element>
     <xs:element name="other-description" type="nonEmptyString"/>
     <xs:element name="other-manifestation-in-series-ref" type="lcfEntityReference"/>
     <xs:element name="overdue-items" type="xs:int"/>
@@ -402,6 +425,7 @@
     </xs:element>
     <xs:element name="staffed" type="staffedUnstaffed"/>
     <xs:element name="start-date" type="xs:dateTime"/>
+    <xs:element name="start-time" type="xs:time"/>
     <xs:element name="subtitle" type="nonEmptyString"/>
     <xs:element name="suspension-period">
         <xs:complexType>


### PR DESCRIPTION
Replaced element 'library-open-close' with 'library-location-service-period', as per issue #87.