### PR TITLE
Clarification of RQT02 confirmation request

### DIFF
--- a/docs/LCF-CodeLists.md
+++ b/docs/LCF-CodeLists.md
@@ -617,7 +617,7 @@ NOTE – This code list is to be revised in consultation with libraries. The exi
   *Code ID*   |*Code value*   |*Definition*                                               |*Notes*
   ----------- |-------------- |--------------------- |----------------------------------------------
   RQT01       |01             |New request                                                |
-  RQT02       |02             |Confirmation request                                       |LMS may not block request, as the action has already been performed. This request type implements the SIP2 "no block" flag for check-out and check-in requests, typically made to confirm a check-out or check-in that has been performed when the terminal was off-line.
+  RQT02       |02             |Confirmation request                                       |LMS may not block request, as the action has already been performed. This request type implements the SIP2 "no block" flag for check-out and check-in requests, typically made to confirm a check-out or check-in that has been performed when the terminal was off-line.<br/>*(Modified in vx.x.0)*
   RQT03       |03             |Cancel previous request                                    |Cancels a previous request. If there was no previous request or too long a pause since the previous request, the response should contain exception condition code EXC03. Approximately equivalent to use of SIP 2 field BI to indicate cancelation.
   RQT04       |04             |Loan / renewal or reservation fee quotation request only   |Not a loan / renewal or reservation request or confirmation, but simply a request for a loan / renewal or reservation fee quotation
 

--- a/docs/LCF-CodeLists.md
+++ b/docs/LCF-CodeLists.md
@@ -617,7 +617,7 @@ NOTE – This code list is to be revised in consultation with libraries. The exi
   *Code ID*   |*Code value*   |*Definition*                                               |*Notes*
   ----------- |-------------- |--------------------- |----------------------------------------------
   RQT01       |01             |New request                                                |
-  RQT02       |02             |Confirmation request                                       |LMS may not block request, as the action has already been performed.
+  RQT02       |02             |Confirmation request                                       |LMS may not block request, as the action has already been performed. This request type implements the SIP2 "no block" flag for check-out and check-in requests, typically made to confirm a check-out or check-in that has been performed when the terminal was off-line.
   RQT03       |03             |Cancel previous request                                    |Cancels a previous request. If there was no previous request or too long a pause since the previous request, the response should contain exception condition code EXC03. Approximately equivalent to use of SIP 2 field BI to indicate cancelation.
   RQT04       |04             |Loan / renewal or reservation fee quotation request only   |Not a loan / renewal or reservation request or confirmation, but simply a request for a loan / renewal or reservation fee quotation
 

--- a/docs/LCF-DataFrameworks.md
+++ b/docs/LCF-DataFrameworks.md
@@ -920,7 +920,7 @@ Circulation management functions
 
 The check-out / renewal function, if successfully executed, causes an LMS to perform a number of consequential actions to create, delete or modify various entity records. These actions are performed internally within the LMS, so how they are performed is beyond the scope of LCF. Depending upon the precise circumstances, some or all of the following entity record creation, modification or deletion actions might be performed by an LMS:
 
--   Unless this is a confirmation or cancellation of check-out or renewal, an LMS would typically retrieve the patron, item and manifestation records to check the patron’s status and ensure that check-out is permitted and to check for any applicable fees.
+-   Unless this is a confirmation (request type RQT02) or cancellation (request type RQT03) of check-out or renewal, an LMS would typically retrieve the patron, item and manifestation records to check the patron’s status and ensure that check-out is permitted and to check for any applicable fees. An LMS may not block a confirmation request (equivalent to "no block" in SIP2). *(Modified in vx.x.0)*
 
 -   If check-out / renewal is to proceed, an LMS would create a loan record for the specified patron and item and, in the case of renewal, modify or delete the existing loan record. If cancelling a check-out or renewal, an LMS would retrieve and either delete or modify the loan record.
 
@@ -964,7 +964,7 @@ This implies that the terminal application must provide sufficient information i
 
 The check-in function, if successfully executed, causes an LMS to perform a number of consequential actions. These actions are performed internally within the LMS, so how they are performed is beyond the scope of LCF. Depending upon the precise circumstances, some or all of the following entity record modification or creation actions might be performed by an LMS:
 
--   The LMS would retrieve the item record and modify to update circulation status and location.
+-   Unless this is a cancellation (request type RQT03) of check-out or renewal, the LMS would retrieve the item record and modify to update circulation status and location. An LMS may not block a confirmation request (equivalent to "no block" in SIP2). *(Modified in vx.x.0)*
 
 -   The LMS would retrieve the loan record for this item and modify it to update its status.
 

--- a/docs/LCF-RESTWebServiceSpecification.md
+++ b/docs/LCF-RESTWebServiceSpecification.md
@@ -406,14 +406,14 @@ The request is formulated using the HTTP POST method.
 | **1** |              | **/lcf**              |                       | **1**   |             | LCF initial segment |
 | **2** |              | **/1.0**              |                       | **1**   |             | LCF version number. All 1.x.x. versions of this specification will use the string "1.0" here. |
 | **3** |              | **/loans**            |                       | **1**   |             |              |
-| 4     | Q11D01       |                       | confirmation          | 0-1     | Y           |              |
-| 5     | Q11D07       |                       | charge-acknowledged   | 0-1     | Y           | Inclusion of this query parameter with any value other than 'n' or 'N' should be interpreted as indicating that a charge may be created for this loan.                                                                                                         |
+| 4     | Q11D01       |                       | confirmation          | 0-1     | Y           | Implements request type RQT02 confirmation request.<br/>*(Added in vx.x.0)*             |
+| 5     | Q11D07       |                       | charge-acknowledged   | 0-1     | Y           | Inclusion of this query parameter with any value other than 'n' or 'N' should be interpreted as indicating that a charge may be created for this loan. |
 
 A new check-out is performed by creating a new loan record, using LCF function 03 (see above), e.g.
 
     POST http://192.168.0.99:80/lcf/1.0/loans
 
-Request to confirm a new check-out, which the LMS may not normally deny, is indicated by including the 'confirmation' parameter in the request, e.g.
+Request to confirm a new check-out, which the LMS may not normally deny (equivalent to the SIP2 "no block" flag) *(Modified in vx.x.0)*, is indicated by including the 'confirmation' parameter in the request, e.g.
 
     POST http://192.168.0.99:80/lcf/1.0/loans?confirmation=Y
 
@@ -479,6 +479,8 @@ The check-in function involves modification of a loan, using function 04 above, 
     PUT http://192.168.0.99:80/lcf/1.0/loans/1234567654
 
 This presumes that a number of consequential functions are performed server-side.
+
+Note that the query parameter `confirmation=Y`, specified above for check-out requests, may also be used with check-in requests. *(Added in vx.x.0)*
 
 ### Response
 


### PR DESCRIPTION
Documentation of code value RQT02, the elements in the Data Framework that use code list RQT, and the description of the 'circulation' parameter in the REST web service implementation of circulation functions 11 and 12 have been extended to explain that a confirmation request implements the SIP2 "no block" flag for use when confirming items that were checked out or in while the terminal application was off-line.