### PR TITLE
Acknowledgement required

### DIFF
--- a/docs/LCF-CodeLists.md
+++ b/docs/LCF-CodeLists.md
@@ -457,7 +457,7 @@ NOTE – This code list is to be revised in consultation with libraries. The exi
 
   *Code ID*   |*Code value*   |*Definition*                                 |*Notes*
   ----------- |-------------- |-------------------------------------------- |---------
-  MGT01       |01             |Whole message (e.g. for screen display)      |
+  MGT01       |01             |Whole message (e.g. for screen display), not requiring acknowledgement | Revised in Issue 5*
   MGT02       |02             |Single line of message (e.g. for printing)   |
   MGT03       |03             | System message (not normally for display)   |
   MGT04       |04             | Whole message, requires acknowledgement     | *Added in Issue 5*

--- a/docs/LCF-CodeLists.md
+++ b/docs/LCF-CodeLists.md
@@ -460,6 +460,7 @@ NOTE – This code list is to be revised in consultation with libraries. The exi
   MGT01       |01             |Whole message (e.g. for screen display)      |
   MGT02       |02             |Single line of message (e.g. for printing)   |
   MGT03       |03             | System message (not normally for display)   |
+  MGT04       |04             | Whole message, requires acknowledgement     | *Added in Issue 5*
 
 ### <a id="MNA"></a>MNA Manifestation association type *(Added vx.x.0)*
 
@@ -625,6 +626,7 @@ NOTE – This code list is to be revised in consultation with libraries. The exi
   RDN07                                              |07             |Charge status exception – over-payment                            |
   RDN08   |08             |Unable to accept payment – see message                            |Further information, if any, should be conveyed in response message.
   RDN09                                              |09             |Unable to accept some/all payment items in request – see detail   
+  RDN10                                              |10             |Request requires acknowledgement - see response message           |*Added in Issue 5*
 
 ### <a id="RNQ"></a>RNQ Renewal request type
 

--- a/docs/LCF-DataFrameworks.md
+++ b/docs/LCF-DataFrameworks.md
@@ -794,7 +794,8 @@ The following data elements and composites are typically used for control of mes
 | R00D05.3   | Element reference          |            | 0-1     | String    | A reference (e.g. the LCF element ID) that uniquely identifies the element in the request payload that generated the exception condition.            |
 | *R00C06*   | *Response message*         | AF / AG    | 0-n     |           | Composite element containing text to display or print on terminal.                                                                                  |
 | R00D06.1   | Message display type       |            | 1       | Code      | LCF code list **[MGT](LCF-CodeLists.md#MGT)**           |
-| R00D06.2   | Message to display         |            | 1-n     | String    | Repeatable if display type is ‘single line’                                                                                                          |
+| R00D06.2   | Message to display         |            | 1-n     | String    | Repeatable if display type is ‘single line’             |
+| R00D06.3   | Acknowledgement code       |            | 0-1     | String    | Library-specific code to be included in a repeat request, for the request to be accepted; only included if R00D05.2 contains '10'  (request requires acknowledgement)<br/>*Added in vx.x.0* |
 
 Core functions
 --------------


### PR DESCRIPTION
Change agreed in issue #84, to require that the client acknowledge that a request has been accepted. Note that the proposed change corrects a typo in the issue discussion: 'in the description of R00D06.3, 'R00D06.1 contains '10' " should read "R00D05.2 contains '10' ".