### PR TITLE
Location associated with an authorisation type

### DIFF
--- a/docs/LCF-DataFrameworks.md
+++ b/docs/LCF-DataFrameworks.md
@@ -639,6 +639,7 @@ A patron authorisation code: either a standard code from LCF code list [AUT](LCF
 | E13D04.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E13D04.2   | Note date-time             |            | 0-1     | DateTime   |                                |
 | E13D04.3   | Note text                  |            | 1       | String     |                                |
+| E13D05     | Location reference         |            | 0-n     | String     | Location associated with this authorisation type (e.g. AUT03)<br/>*Added in vx.x.0* |
 
 ***
 

--- a/docs/LCF-DataFrameworks.md
+++ b/docs/LCF-DataFrameworks.md
@@ -639,7 +639,7 @@ A patron authorisation code: either a standard code from LCF code list [AUT](LCF
 | E13D04.1   | Note type                  |            | 0-1     | Code       | LCF code list **[NOT](LCF-CodeLists.md#NOT)**          |
 | E13D04.2   | Note date-time             |            | 0-1     | DateTime   |                                |
 | E13D04.3   | Note text                  |            | 1       | String     |                                |
-| E13D05     | Location reference         |            | 0-n     | String     | Location associated with this authorisation type (e.g. AUT03)<br/>*Added in vx.x.0* |
+| E13D05     | Location reference         |            | 0-n     | String     | Location associated with this authorisation type (e.g. AUT03)<br/>*Added in vx.x.0*<br/>*NOTE: This element is intended for use in responses to Patron requests to retrieve their authorisation(s), which may include access to one or more library locations when un-staffed (authorisation code 'ACC'). The control of access to a library location is out of scope for LCF.* |
 
 ***
 

--- a/docs/LCF-InformationEntityXMLBindings.md
+++ b/docs/LCF-InformationEntityXMLBindings.md
@@ -445,6 +445,7 @@ E13 AUTHORISATION CODE *(added in v1.0.1)*
 |   5   | E13D04.1     | note-type                   | 0-1     | Code        | [NOT](LCF-CodeLists.md#NOT) |
 |   6   | E13D04.2     | date-time                   | 0-1     | dateTime    |         |
 |   7   | E13D04.3     | note-text                   | 1       | string      |         |
+|   8   | E13D05       | location-ref                | 0-n     | string      | *Added in vx.x.0* |
 
 E14 LIBRARY AUTHORITY/INSTITUTION *(added in v1.0.1)*
 ---------------------------------


### PR DESCRIPTION
Adding E13D05 to Data Framework and to the XML Binding, to allow one or more library locations to be associated with an Authorisation of type AUT03 (consent to gain access to the location when un-staffed). See issue #295.