### PR TITLE
E15 Message, description update proposal

### DIFF
--- a/docs/LCF-DataFrameworks.md
+++ b/docs/LCF-DataFrameworks.md
@@ -733,13 +733,13 @@ All message entities must have a type, indicated by the [MAT](LCF-CodeLists.md#M
 | E15D04     | Message/alert priority     |            | 0-1     | Code       | LCF code list **[MAP](LCF-CodeLists.md#MAP)**                                                                                                  |
 | E15D05     | Message/alert display type |            | 0-1     | Code       | LCF code list **[MGT](LCF-CodeLists.md#MGT)**                                                                                                  |
 | E15D06     | Display/delivery constraint |          | 0-1     | Code       | LCF code list **[MAC](LCF-CodeLists.md#MAC)**                                                                                                  |
-| E15D07     | Display from date-time     |            | 0-1     | DateTime   | Only permitted when the delivery contraint is MAC01.          |
-| E15D08     | Display until date-time    |            | 0-1     | DateTime   | Only permitted when the delivery constraint is MAC01.                               |
+| E15D07     | Display from date-time     |            | 0-1     | DateTime   | Only permitted when the delivery constraint is MAC01          |
+| E15D08     | Display until date-time    |            | 0-1     | DateTime   | Only permitted when the delivery constraint is MAC01                              |
 | E15D09     | Message/alert audience     |            | 0-1     | Code       | LCF code list **[MAU](LCF-CodeLists.md#MAU)**                                                                                                  |
-| E15D10     | Patron category            |            | 0-n     | String     | Only included if audience is specified patrons and categories |
-| E15D11     | Patron reference           |            | 0-n     | String     | Only included if audience is specified patrons and categories |
-| E15D14     | Loan reference             |            | 0-n     | String     | Only included if audience is patrons related to specified loans |
-| E15D15     | Reservation reference      |            | 0-n     | String     | Only included if audience is patrons related to specified reservations |
+| E15D10     | Patron category            |            | 0-n     | String     | Only included if audience MAU02 is specified. Patron Category is a library-specific value |
+| E15D11     | Patron reference           |            | 0-n     | String     | Only included if audience MAU02 is specified |
+| E15D14     | Loan reference             |            | 0-n     | String     | Only included if audience MAU03 'patrons related to specified loans' is specified |
+| E15D15     | Reservation reference      |            | 0-n     | String     | Only included if audience MAU04 'patrons related to specified reservations' is specified |
 | ***E15C12***  | **Message/alert text**  |            | **1-n** |            | Repeatable if the message/alert text is available in several alternative text formats                                                               |
 | **E15D12.1**  | Text format             |            | **1**   | Code       | LCF code list **[TFT](LCF-CodeLists.md#TFT)**                                                                                                  |
 | **E15D12.2**  | Text string             |            | **1**   | String     |                                |

--- a/docs/LCF-DataFrameworks.md
+++ b/docs/LCF-DataFrameworks.md
@@ -712,7 +712,16 @@ An entity representing a single node in the logical structure for a library or w
 
 #### Description
 
-A message or alert that may be communicated to a patron or group of patrons.
+A message is any form of communication that should be displayed to any group of Patrons or an individual Patron.
+
+Messages for a specific [Patron](#e03) are typically retrieved through a request for the Patron record, which includes the associated messages for a specific Patron in field E03C34. This follows the use case for a self-service terminal, where the Patron is known and using the terminal. 
+
+Messages which require acknowledgement should follow [LCF function 32](#f32), confirming which messages have been acknowledged by the Patron.  
+
+All message entities must have a type, indicated by the [MAT](LCF-CodeLists.md#MAT) code list, indicating whether action is required, or whether the message relates to the Institutional, Collection, or Patron  level notices. 
+* Examples of Institution-level messages include opening hours, holiday closure periods, where the library as a whole may be unavailable, etc.
+* Examples of Collection-level messages include additions or removal of items from collections, whether there are rule changes for accessing collections, etc.
+* Examples of Patron-level messages include lost property or specific messages about fees or fines for one specific Patron, etc.
 
 #### Properties
 
@@ -724,8 +733,8 @@ A message or alert that may be communicated to a patron or group of patrons.
 | E15D04     | Message/alert priority     |            | 0-1     | Code       | LCF code list **[MAP](LCF-CodeLists.md#MAP)**                                                                                                  |
 | E15D05     | Message/alert display type |            | 0-1     | Code       | LCF code list **[MGT](LCF-CodeLists.md#MGT)**                                                                                                  |
 | E15D06     | Display/delivery constraint |          | 0-1     | Code       | LCF code list **[MAC](LCF-CodeLists.md#MAC)**                                                                                                  |
-| E15D07     | Display from date-time     |            | 0-1     | DateTime   |                                |
-| E15D08     | Display until date-time    |            | 0-1     | DateTime   |                                |
+| E15D07     | Display from date-time     |            | 0-1     | DateTime   | Only permitted when the delivery contraint is MAC01.          |
+| E15D08     | Display until date-time    |            | 0-1     | DateTime   | Only permitted when the delivery constraint is MAC01.                               |
 | E15D09     | Message/alert audience     |            | 0-1     | Code       | LCF code list **[MAU](LCF-CodeLists.md#MAU)**                                                                                                  |
 | E15D10     | Patron category            |            | 0-n     | String     | Only included if audience is specified patrons and categories |
 | E15D11     | Patron reference           |            | 0-n     | String     | Only included if audience is specified patrons and categories |


### PR DESCRIPTION
As per the Review Group meeting today, proposal on the updated description for E15 Message, including the change to highlight the start/end dates for a message should only be provided for the CON01 constraint.